### PR TITLE
Generator (to know when / points up at) support

### DIFF
--- a/folk.tcl
+++ b/folk.tcl
@@ -27,6 +27,16 @@ proc When {args} {
     Wish to know when {*}$clause
 }
 
+# To know when /a/ points up at /b/
+proc To {_know _when args} {
+    set clause [lreplace $args end end]
+    set cb [lindex $args end]
+
+    When /someone/ wishes to know when {*}$clause {
+        eval $cb
+    }
+}
+
 # With all /matches/ for /blah/ is a rectangle 
 proc With {_all matches _for args} {
     set clause [lreplace $args end end]
@@ -37,15 +47,6 @@ proc With {_all matches _for args} {
     # then do another evaluation round
 }
 
-# To know when /known a/ points up at /unknown b/
-proc To {_know _when args} { # FIXME
-    set clause [lreplace $args end end]
-    set cb [lindex $args end]
-
-    When /someone/ wishes to know when {*}$clause {
-        eval $cb
-    }
-}
 
 set ::assertedStatements [dict create]
 proc Assert {args} {
@@ -185,6 +186,17 @@ Always {
         # Wish $rect is highlighted $Display::blue
     }
 
+    To know when /a/ points up at /b/ {
+        When $a is a rectangle with x /ax/ y /ay/ width /awidth/ height /aheight/ {
+            # TODO: we'll probably need join support
+            When $b is a rectangle with x /bx/ y /by/ width /bwidth/ height /bheight/ {
+                if {$by + $bheight <= $ay && $ay - ($by + $bheight) < 10} {
+                    Claim $a points up at $b
+                }
+            }
+        }
+    }
+
     # this defines $this in the contained scopes
     When /this/ has program code /code/ {
         eval $code
@@ -201,7 +213,7 @@ after 200 {
         Claim the dog is out
         When the /animal/ is out {
             When the /animal/ is around {
-                puts "the $animal is around"
+                 puts "the $animal is around"
             }
             puts "there is a $animal out there somewhere"
             Claim the $animal is around
@@ -218,17 +230,6 @@ after 400 {
 
         Claim "rect2" is a rectangle with x 300 y 460 width 20 height 20
         Wish "rect2" is highlighted $Display::blue
-
-        To know when /a/ points up at /b/ { # FIXME
-            When $a is a rectangle with x /ax/ y /ay/ width /awidth/ height /aheight/ {
-                # TODO: we'll probably need join support
-                When $b is a rectangle with x /bx/ y /by/ width /bwidth/ height /bheight/ {
-                    if {$by + $bheight <= $ay && $ay - ($by + $bheight) < 10} {
-                        Claim $a points up at $b
-                    }
-                }
-            }
-        }
         
         When "rect2" points up at "rect1" { # FIXME
             puts "points up"


### PR DESCRIPTION
It's not quite done yet, but

https://user-images.githubusercontent.com/96857/167995648-f0c817b9-c42a-43fb-8d2b-b0c3bf9eb827.mov

(there is a problem where you have to say `/b/` for the second rectangle in the code above, if you say `/that/` then it doesn't work due to truly weird substitution behavior that i'm relying on)

we might need to think about:

- syntax `known`/`unknown` vs `bound`/`free` vs do we even need that distinction? (we don't have it in this PR yet)

- meta-statements. it may get slow over time. maybe we have to optimize them out or ignore them in a lot of cases or add metadata to them so we can ignore them

- do we need generators at all? what if you explicitly `Wish $this has upward whisker` or whatever and then can query using that upward whisker as an object to see what it overlaps (i do think that in RT we regretted not having whiskers be addressable objects, so this may be an opportunity to remediate that)


this also adds somewhat more legit fake lexical scope than before, where it serializes all local variables at the time that a `When` is set up, so now you should be able to do
```
set x 300
When $this is cool {
    puts $x
}
```
and it should work (`$x` should be 300). whereas before, you could only access match variables inside the When block
(note that these aren't real closures -- ie you can't mutate `x` and expect that mutation to be accessible anywhere after your block is done executing. it's just a way to pass immutable data down)