### PR TITLE
Update pixel multiplier

### DIFF
--- a/useful/apriltags.tcl
+++ b/useful/apriltags.tcl
@@ -8,7 +8,7 @@ proc drawTag {id sizeInches} {
     set tagPng tag52_13_[format %-05s $id].png
     puts [exec identify $tagPng]
 
-    set sizePx [expr $sizeInches * 144]
+    set sizePx [expr $sizeInches * 172]
     set outPng [exec mktemp -t test_tag_[set sizeInches]in].png
     exec convert $tagPng -filter point -resize [set sizePx]x[set sizePx] -bordercolor white -border 20 \
         -pointsize 24 "label:$sizeInches in" -gravity Center \


### PR DESCRIPTION
My printer at home printed the 1 inch AprilTag as an outline due to being low on ink but measured against a ruler it's 1 inch!

![ruler showing marker appears as 1 inch upon being printed](https://user-images.githubusercontent.com/5826638/171087446-9de2efdc-2189-4087-bcf7-28cc67063a3a.jpeg)

