### PR TITLE
edit existing table programs from a web editor

### DIFF
--- a/virtual-programs/print.folk
+++ b/virtual-programs/print.folk
@@ -201,6 +201,26 @@ When /someone/ wishes to print /code/ with job id /jobid/ {
     exec ps2pdf $::env(HOME)/folk-printed-programs/$id.ps $::env(HOME)/folk-printed-programs/$id.pdf
     exec lpr $::env(HOME)/folk-printed-programs/$id.pdf
 }
+When /someone/ wishes to print program /id/ with code /code/ with job id /jobid/ {
+    puts "Wish to print jobid $jobid"
+    if {[dict exists $::printjobs $jobid]} {return}
+
+    dict set ::printjobs $jobid [list $id $code]
+
+    set format "letter"
+    if {[string first {Wish $this prints on an index card} $code] != -1} {
+       set format "indexcard"
+    }
+
+    set ps [programToPs $id $code $format front]
+
+    set fp [open "$::env(HOME)/folk-printed-programs/$id.ps" w]
+    puts $fp $ps
+    close $fp
+
+    exec ps2pdf $::env(HOME)/folk-printed-programs/$id.ps $::env(HOME)/folk-printed-programs/$id.pdf
+    exec lpr $::env(HOME)/folk-printed-programs/$id.pdf
+}
 When /someone/ wishes to print the back of job id /jobid/ {
     lassign [dict get $::printjobs $jobid] id code
 

--- a/web.tcl
+++ b/web.tcl
@@ -5,7 +5,7 @@ package require websocket
 proc handleConnect {chan addr port} {
     fileevent $chan readable [list handleRead $chan $addr $port]
 }
-proc htmlEscape {s} { string map {& "&amp;" < "&lt;" > "&gt;"} $s }
+proc htmlEscape {s} { string map {& "&amp;" < "&lt;" > "&gt;" "\"" "&quot;"} $s }
 # TODO: Catch errors & return 501
 proc handlePage {path contentTypeVar} {
     upvar $contentTypeVar contentType
@@ -57,10 +57,95 @@ proc handlePage {path contentTypeVar} {
         set file_data [read $fp]
         close $fp
 
-        return [subst {
+        return [string map [list file_data [htmlEscape $file_data] my_page_number $pageNumber] {
             <html>
             <body>
-            <pre>[htmlEscape $file_data]</pre>
+            <div>
+                <span id="status">Status</span>
+                <button onclick="handleSave()">Save</button>
+                <button onclick="handlePrint()">Print</button>
+            </div>
+            <textarea id="code" style="width: 100%;height: 95vh;">file_data</textarea>
+            <pre id="error"></pre>
+<script>
+const codeEle = document.getElementById("code");
+function uuidv4() {
+  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+  );
+}
+
+// Cmd + S || Ctrl + S => Save
+document.addEventListener('keydown', function(e) {
+  if ((window.navigator.platform.match('Mac') ? e.metaKey : e.ctrlKey)  && e.keyCode == 83) {
+    e.preventDefault();
+    handleSave();
+  }
+}, false);
+// Cmd + P || Ctrl + P => Print
+document.addEventListener('keydown', function(e) {
+  if ((window.navigator.platform.match('Mac') ? e.metaKey : e.ctrlKey)  && e.keyCode == 80) {
+    e.preventDefault();
+    handlePrint();
+  }
+}, false);
+
+let ws;
+let send;
+function wsConnect() {
+    ws = new WebSocket(window.location.origin.replace("http", "ws") + "/ws");
+    send = function(s) { ws.send(s); }
+
+    ws.onopen = () => {
+        document.getElementById('status').innerHTML = "<span style=background-color:seagreen;color:white;>Connnected</span>";
+    };
+    ws.onclose = window.onbeforeunload = () => {
+        document.getElementById('status').innerHTML = "<span style=background-color:red;color:white;>Disconnnected</span>";
+
+        setTimeout(() => { wsConnect(); }, 1000);
+    };
+    ws.onerror = (err) => {
+        document.getElementById('status').innerText = "Error";
+        console.error('Socket encountered error: ', err.message, 'Closing socket');
+        ws.close();
+    }
+  ws.onmessage = (msg) => {
+    if (msg.data.startsWith("ERROR:")) {
+      const errorEl = document.getElementById("error");
+      if (msg.data == "ERROR: {}") {
+        errorEl.style.backgroundColor = "";
+        errorEl.innerText = "";
+      } else {
+        errorEl.style.backgroundColor = "#f55";
+        errorEl.innerText = msg.data;
+      }
+    }
+  }
+};
+wsConnect();
+
+function handleSave() {
+    const code = document.getElementById("code").value;
+  send(`
+set fp [open "../folk-printed-programs/my_page_number.folk" w]
+puts -nonewline $fp {${code}}
+close $fp
+puts "Saved my_page_number.folk"
+`);
+    setTimeout(() => {
+      send(`list ERROR: [Statements::findMatches [list my_page_number has error /err/ with info /errorInfo/]]`);
+    }, 500);
+}
+let jobid;
+function handlePrint() {
+    const code = document.getElementById("code").value;
+    jobid = String(Math.random());
+    send(`Assert web wishes to print program my_page_number with code {${code}} with job id {${jobid}}`);
+    setTimeout(500, () => {
+      send(`Retract web wishes to print program my_page_number with code {${code}} with job id {${jobid}}`);
+    });
+}
+</script>
             </body>
             </html>
         }]


### PR DESCRIPTION
Adds in a basic web editor for existing program pages. This was useful to me to edit and reprint programs I find laying on the desk the next day because we don't have an editor on the table yet.

Currently the editor is limited to `folk-printed-programs` and you can't use it to open to edit virtual-programs.

I'm happy to clean things up before merging if someone has ideas!