### PR TITLE
Don't stroke if both points are equal

### DIFF
--- a/pi/Display.tcl
+++ b/pi/Display.tcl
@@ -246,7 +246,8 @@ namespace eval Display {
         for {set i 0} {$i < [llength $points]} {incr i} {
             set a [lindex $points $i]
             set b [lindex $points [expr $i+1]]
-            if {$b == "" || $a eq $b} break
+            if {$b == ""} break
+	    if {$a eq $b} continue
 
             # if line is past edge of screen, clip it to the nearest
             # point along edge of screen


### PR DESCRIPTION
This throws an error when getting the unit length of an empty nudge vector