### PR TITLE
add warp image function

### DIFF
--- a/virtual-programs/images.folk
+++ b/virtual-programs/images.folk
@@ -95,6 +95,32 @@ namespace eval ::image {
         jpeg(out, im.data, im.components, im.width, im.height, 100);
         fclose(out);
     }
+    # Given the four corners of a region in an image, warp it to a new image of a given width and height
+    $cc proc warp {image_t im uint32_t tl_x uint32_t tl_y uint32_t tr_x uint32_t tr_y uint32_t br_x uint32_t br_y uint32_t bl_x uint32_t bl_y uint32_t output_width uint32_t output_height} image_t {
+        image_t ret;
+        ret.width = output_width;
+        ret.height = output_height;
+        ret.components = im.components;
+        ret.bytesPerRow = ret.width * ret.components;
+        ret.data = folkHeapAlloc(ret.bytesPerRow * ret.height);
+
+        for (int y = 0; y < output_height; y++) {
+            for (int x = 0; x < output_width; x++) {
+                // calculate the position in the input image
+                float u = (float)x / (float)(output_width - 1);
+                float v = (float)y / (float)(output_height - 1);
+                int input_x = tl_x + u * (int)(tr_x - tl_x) + v * (int)(bl_x - tl_x);
+                int input_y = tl_y + u * (int)(tr_y - tl_y) + v * (int)(bl_y - tl_y);
+
+                if (input_x >= 0 && input_x < im.width && input_y >= 0 && input_y < im.height) {
+                    memcpy(&ret.data[y * ret.bytesPerRow + x * ret.components],
+                        &im.data[input_y * im.bytesPerRow + input_x * im.components],
+                        im.components);
+                }
+            }
+        }
+        return ret;
+    }
     $cc proc loadJpeg {char* filename} image_t {
         FILE* file = fopen(filename, "rb");
         if (!file) {


### PR DESCRIPTION
Adds a function to get an axis-aligned subimage from a image given a region. I am interested in this to do computer vision when papers are not axis-aligned.

The code incorrectly assumes the region is affine because that makes the pixel lookup simple and that is mostly true in practice in my setups. A correct warp would not assume an affine region and would do an inverse perspective lookup which I wasn't sure how to do.

For code review, I am mainly worried about two things:
1. the use of `folkHeapAlloc` - is this necessary or is there a nice way to clean up image after it has been drawn?
2. The ordering of region corners. The warp function works with different ordering of corners, but the resulting image can be flipped if you choose the wrong order. Is there a nicer way to handle this so that you can always get an image where the corners match up?

This is an example program using this new function (but crashes folk soon after because the `$thisimage` is never freed)
```
When the camera frame is /f/ & $this has region /r/ {
  # The ordering of the coordinates works for my setup but I don't think works for all camera setups
  lassign [projectorToCamera [lindex $r 0 3]] x0 y0
  lassign [projectorToCamera [lindex $r 0 2]] x1 y1
  lassign [projectorToCamera [lindex $r 0 1]] x2 y2
  lassign [projectorToCamera [lindex $r 0 0]] x3 y3
  set width [region width $r]
  set height [region height $r]
  set thisimage [image warp $f $x0 $y0 $x1 $y1 $x2 $y2 $x3 $y3 $width $height]

  set center [region centroid [region move $r up 100]]
  Wish display runs [list Display::image {*}$center $thisimage [region angle $r] 1]

  # TODO: need to clear memory for thisimage
  Wish $this is outlined red
}
```
