### PR TITLE
Proper escaping of keyboard keys; change esc-restart modifiers

### DIFF
--- a/pi/pi.tcl
+++ b/pi/pi.tcl
@@ -37,16 +37,11 @@ try {
             }
 
             set heldModifiers [dict keys [dict filter $modifiers value 1]]
-            if {[llength $heldModifiers] == 0} {set heldModifiers none}
 
-            # You can't use some chars in an Assert without backslash-prefixing them
-            if {$key == "\[" || $key == "\{" || $key == "\\"} {
-              set key "\\$key"
-            }
-
+            # Use `list` to escape special chars (brackets, quotes, whitespace)
             thread::send -async "%s" [subst {
                 Retract keyboard claims key /k/ is /t/ with modifiers /m/
-                Assert keyboard claims key "$key" is $keyState with modifiers $heldModifiers
+                Assert keyboard claims key [list $key] is [list $keyState] with modifiers [list $heldModifiers]
             }]
         }
     } [thread::id]]]

--- a/virtual-programs/esc-restart.folk
+++ b/virtual-programs/esc-restart.folk
@@ -1,3 +1,3 @@
-When keyboard claims key /key/ is /t/ with modifiers /m/ {
-	if {[string tolower $key] == "esc"} {exec sudo systemctl restart folk}
+When keyboard claims key ESC is down with modifiers alt {
+	exec sudo systemctl restart folk
 }


### PR DESCRIPTION
1. Escape words in `subst` by wrapping them in a list! I took this tip from the "Generating Scripts and Lists" section of https://wiki.tcl-lang.org/page/subst

2. Change the esc-restart key from plain ESC to alt-ESC, so you can use the escape key in vim terminals.