### PR TITLE
Center shapes, add more shapes

### DIFF
--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -1,41 +1,3 @@
-set sizeDict [dict create small 1 medium 4 large 10]
-
-proc isSizeWord {word} {
-  expr {[lsearch [list small medium large] $word] >= 0}
-}
-
-proc rectangle {x y w h {strokeWeight 5} {color "white"}} {
-  set start [list $x $y]
-  set points [list $start]
-
-  puts [list [expr {$x + $w}] $y]
-
-  lappend points [list [expr {$x + $w}] $y]
-  lappend points [list [expr {$x + $w}] [expr {$y + $h}]]
-  lappend points [list $x [expr {$y + $h}]]
-  lappend points $start
-  Display::stroke $points $strokeWeight $color
-}
-
-proc square {x y w {strokeWeight 5} {color "white"} args} {
-  rectangle $x $y $w $w $strokeWeight $color
-}
-
-proc regionToInnerRect {region} {
-    set vertices [lindex $region 0]
-    lassign $vertices a b c d
-    lassign $a aX aY
-    lassign $c cX cY
-    set shrinkConstant 0.65
-    set width [expr {($cX - $aX) * $shrinkConstant}]
-    set height [expr {($cY - $aY) * $shrinkConstant}]
-    set x [expr {$aX + $width * 0.25}]
-    set y [expr {$aY + $height * 0.25}]
-    return [list $x $y $width $height]
-}
-
-# --- Wish $this has ... ----
-
 # numPoints 2 => line
 # numPoints 3 => triangle
 # numPoints 4 => square
@@ -58,9 +20,6 @@ proc shape {numPoints x y r {color white} {filled false} args} {
 }
 
 When /someone/ wishes /p/ draws a /color/ /shape/ offset /offsetVector/ & /p/ has region /r/ {
-  # --------------
-  # TODO: Remove magic numbers, replace with consistent math defined off of centroid, width, and height
-  # --------------
   lassign [region centroid $r] x y
   set width [region width $r]
   set height [region height $r]
@@ -73,38 +32,75 @@ When /someone/ wishes /p/ draws a /color/ /shape/ offset /offsetVector/ & /p/ ha
     set y [expr {$y + $offsetY}]
   }
 
-  # Hmmmm, what's the point of adjustedWidth? To compensate for the wacky shape function?
-  # Solution is to probably refactor shae to return linked points of consistent size from centroid.
-  set adjustedWidth [expr {$width * 0.25}]
-  set x [expr { $x * 1.3}]
-  set y [expr { $y * 1.25}]
+  # puts "drawing a $shape at $x $y with width $width and height $height"
+  set radius 50
   switch -nocase $shape {
     triangle {
-      shape 3 $x $y $adjustedWidth $color
+      shape 3 $x $y $radius $color
     }
     square {
-      shape 4 $x $y $adjustedWidth $color
+      shape 4 $x $y $radius $color
     }
-    # TODO: cwervo - fix magic numbers here
+    pentagon {
+      shape 5 $x $y $radius $color
+    }
+    hexagon {
+      shape 6 $x $y $radius $color
+    }
+    septagon {
+      shape 7 $x $y $radius $color
+    }
+    octagon {
+      shape 8 $x $y $radius $color
+    }
+    nonagon {
+      shape 9 $x $y $radius $color
+    }
     circle {
-      shape 30 [expr {$x * 0.94}] $y [expr {$adjustedWidth * 0.1}] $color
+      Display::circle $x $y $radius 5 $color
     }
     default {
-      shape 5 $x $y $adjustedWidth $color
+      shape 2 $x $y $radius $color
     }
   }
 }
+
+set defaultColor white
 
 When /someone/ wishes /p/ draws a /color/ /shape/ & /p/ has region /r/ {
   Wish $p draws a $color $shape offset {0 0}
 }
 
 When /someone/ wishes /p/ draws a /shape/ & /p/ has region /r/ {
-  Wish $p draws a white $shape
+  Wish $p draws a $defaultColor $shape
 }
 
 When /someone/ wishes /p/ draws a /shape/ offset /offsetVector/ {
-  Wish $p draws a white $shape offset $offsetVector 
+  Wish $p draws a $defaultColor $shape offset $offsetVector 
 }
 
-# --- TODO: Wish table has ... ----
+Claim $this has demo {
+  Wish $this draws a circle
+  Wish $this draws a skyblue triangle
+  Wish $this draws a green triangle offset {280 0}
+  Wish $this draws a gold pentagon offset {200 0}
+  Wish $this draws a red octagon offset {250 80}
+
+  When the clock time is /t/ {
+    set offsetVector [list [sin $t] [cos $t]]
+    set offsetVector [::vec2::scale $offsetVector 105]
+    Wish $this draws a palegoldenrod circle offset $offsetVector
+  }
+
+  # This toggles a square between filled and unfilled
+  # TODO cwervo: Support `Wish $this draws a circle with options /optionsDict/` to make this cleaner
+  # optionsDisct: {size number?: 50, filled boolean?: false, color string?: white, thickness string? white }
+  When $this has region /r/ & the clock time is /t/ {
+    lassign [region centroid $r] x y
+    set fill [expr {round(sin($t) * 2) % 2 == 0 ? true : false}]
+    set y [- $y 150]
+    shape 4 [- $x 100] $y 60 white $fill
+  }
+
+  Wish $this is outlined white
+}


### PR DESCRIPTION
1. This draws all all shapes made via `shapes.folk` relative to the center of the region they reference
2. This adds 5 → 9-gons to the list of shapes (e.g. `Wish $this draws red nonagon`)
3. Add a `Claim $this has demo ...` to the end of the file. We don't use this yet but @osnr and I were chatting and we could make a tool that allows you to view all `demo` programs for a Folk system in the future.