### PR TITLE
Some small fixes to region math

### DIFF
--- a/lib/math.tcl
+++ b/lib/math.tcl
@@ -273,15 +273,21 @@ namespace eval ::region {
             if {![regexp {([0-9\.]+)(px|%)?} $distance -> distance unit]} {
                 error "region move: Invalid distance $distance"
             }
+            if {$direction ne "left" && $direction ne "right" &&
+                $direction ne "up" && $direction ne "down"} {
+                error "region move: Invalid direction $direction"
+            }
+
             if {$unit eq "%"} {
+                set distance [* $distance 0.01]
                 set unit ""
             }
             if {$unit eq ""} {
                 # Convert to pixels
                 if {$direction eq "left" || $direction eq "right"} {
-                    set distance [expr {[width $r] * $distance * 0.01}]
+                    set distance [expr {[width $r] * $distance}]
                 } elseif {$direction eq "up" || $direction eq "down"} {
-                    set distance [expr {[height $r] * $distance * 0.01}]
+                    set distance [expr {[height $r] * $distance}]
                 }
             }
             set dxp [if {$direction eq "left"} {- $distance} \


### PR DESCRIPTION
1. Move scaling out of the loop - otherwise it is done twice
2. It should be possible to layout a series of regions like this:

```
set halfwidth 85
set halfheight 110

set corners [list [list -$halfwidth $halfheight] [list $halfwidth $halfheight] [list $halfwidth -$halfheight] [list -$halfwidth -$halfheight]]
set frame [region create $corners [list [list 0 1] [list 1 2] [list 2 3] [list 3 0]] 0]

lassign [region centroid $r] cx cy

for {set i 0} {$i < $count} {incr i} {
      set newr $frame
      set newr [region move $newr right ${cx}px down ${cy}px]
      set newr [region move [region rotate $newr [region angle $r]] right [expr {$i * 100}]%]

      set f "Frame [expr {$i+1}]"
      Claim $f has region $newr
}
```