### PR TITLE
Support other objects having programs

### DIFF
--- a/virtual-programs/programs.folk
+++ b/virtual-programs/programs.folk
@@ -1,0 +1,22 @@
+
+
+When (non-capturing) /type/ /obj/ has a program {
+    puts "Added $type $obj"
+    On unmatch { puts "Removed $type $obj" }
+
+    try {
+    set tempPath "$::env(HOME)/folk-printed-programs/$obj.folk.temp"
+
+    if {[file exists $tempPath]} {
+      set path [open "$::env(HOME)/folk-printed-programs/$obj.folk.temp" r]
+    } else {
+      set path [open "$::env(HOME)/folk-printed-programs/$obj.folk" r]
+    }
+     set code [read $path]
+     close $path
+
+     Claim $obj has program code $code
+     } on error error {
+      puts stderr "No code for $type $obj"
+     }
+}

--- a/virtual-programs/tags-and-calibration.folk
+++ b/virtual-programs/tags-and-calibration.folk
@@ -114,28 +114,6 @@ When camera /camera/ has width /cameraWidth/ height /cameraHeight/ {
     }
 }
 
-When (non-capturing) tag /tag/ has center /c/ size /size/ {
-     Claim tag $tag is a tag
-}
-
-When (non-capturing) tag /tag/ is a tag {
-    puts "Added tag $tag"
-    On unmatch { puts "Removed tag $tag" }
-
-    set tempPath "$::env(HOME)/folk-printed-programs/$tag.folk.temp"
-
-    if {[file exists $tempPath]} {
-      set path [open "$::env(HOME)/folk-printed-programs/$tag.folk.temp" r]
-    } else {
-      set path [open "$::env(HOME)/folk-printed-programs/$tag.folk" r]
-    }
-     set code [read $path]
-     close $path
-
-     # Wish $tag is outlined green
-     Claim $tag has program code $code
-}
-
 When (non-capturing) tag /tag/ has corners /corners/ {
     set tagCorners [lmap p $corners {::cameraToProjector $p}]
 
@@ -156,4 +134,5 @@ When (non-capturing) tag /tag/ has corners /corners/ {
     set region [region create $corners $edges $angle]
 
     Claim $tag has region $region
+    Claim tag $tag has a program
 }


### PR DESCRIPTION
I'm currently prototyping recognizing single tagStandard56h13 tags as standalone programs, and dual tag36h11 tagged areas as another type of folk object.

This should also open the way to add programs to more types of recognized objects.