### PR TITLE
Add horizontal and vertical text alignment

### DIFF
--- a/virtual-programs/display/text.folk
+++ b/virtual-programs/display/text.folk
@@ -224,29 +224,36 @@ On process "display" {
         set scale [dict_getdef $options scale 1.0]
         set font [dict_getdef $options font "PTSans-Regular"]
         set text [dict get $options text]
-        set halign [dict_getdef $options halign "center"]
-        set valign [dict_getdef $options valign "center"]
+        set anchor [dict_getdef $options anchor "center"]
         set radians [dict get $options radians]
         set color [getColor [dict_getdef $options color white]]
 
-        if {$halign == "left"} { 
-            set halign_enum -1
-        } elseif {$halign == "right"} {
-            set halign_enum 1
-        } else { set halign_enum 0 }
-
-        if {$valign == "top"} { 
-            set valign_enum -1
-        } elseif {$valign == "bottom"} {
-            set valign_enum 1
-        } else { set valign_enum 0 }
+        if {$anchor == "topleft"} {
+            set align [list -1 -1]
+        } elseif {$anchor == "top"} {
+            set align [list 0 -1]
+        } elseif {$anchor == "topright"} {
+            set align [list 1 -1]
+        } elseif {$anchor == "left"} {
+            set align [list -1 0]
+        } elseif {$anchor == "center"} {
+            set align [list 0 0]
+        } elseif {$anchor == "right"} {
+            set align [list 1 0]
+        } elseif {$anchor == "bottomleft"} {
+            set align [list -1 1]
+        } elseif {$anchor == "bottom"} {
+            set align [list 0 1]
+        } elseif {$anchor == "bottomright"} {
+            set align [list 1 1]
+        }
 
         if {!([dict exists $::FontCache $font])} {
             throw {DISPLAY FONT {font doesn't exist}} "$font doesn't exist"
         }
         set font [dict get $::FontCache $font]
 
-        set instances [font textShape $font $text $x0 $y0 $scale $halign_enum $valign_enum $radians $color]
+        set instances [font textShape $font $text $x0 $y0 $scale {*}$align $radians $color]
 
         # We need to batch into one wish so we don't deal with n^2
         # checks for existing statements for n glyphs.

--- a/virtual-programs/title.folk
+++ b/virtual-programs/title.folk
@@ -11,34 +11,34 @@ When /thing/ has region /region/ {
     
         set scale [dict_getdef $match scale 1.0]
         set pos [region top [region move $region up 10px]]
-        Wish to draw text with position $pos scale $scale text $text radians $radians valign bottom
+        Wish to draw text with position $pos scale $scale text $text radians $radians anchor bottom
     }
 
-    When the collected matches for [list /someone/ wishes $thing is footnoted /text/ with scale /scale/] are /matches/ {
+    When the collected matches for [list /someone/ wishes $thing is footnoted /text/] are /matches/ {
         set text [join [lmap match $matches {dict get $match text}] "\n"]
         if {$text eq ""} { return }
 
         set scale [dict_getdef $match scale 0.75]
-        set pos [region bottom [region move $region down 10px]]
-        Wish to draw text with position $pos scale $scale text $text radians $radians valign top
+        set pos [region bottomleft [region move $region down 20px]]
+        Wish to draw text with position $pos scale $scale text $text radians $radians anchor topleft
     }
     
-    When the collected matches for [list /someone/ wishes $thing is right margined /text/ with scale /scale/] are /matches/ {
+    When the collected matches for [list /someone/ wishes $thing is right-margined /text/] are /matches/ {
         set text [join [lmap match $matches {dict get $match text}] "\n"]
         if {$text eq ""} { return }
     
         set scale [dict_getdef $match scale 0.75]
         set pos [region right [region move $region right 10px]]
-        Wish to draw text with position $pos scale $scale text $text radians $radians halign left
+        Wish to draw text with position $pos scale $scale text $text radians $radians anchor left
     }
 
-    When the collected matches for [list /someone/ wishes $thing is left margined /text/ with scale /scale/] are /matches/ {
+    When the collected matches for [list /someone/ wishes $thing is left-margined /text/] are /matches/ {
         set text [join [lmap match $matches {dict get $match text}] "\n"]
         if {$text eq ""} { return }
     
         set scale [dict_getdef $match scale 0.75]
         set pos [region left [region move $region left 10px]]
-        Wish to draw text with position $pos scale $scale text $text radians $radians halign left
+        Wish to draw text with position $pos scale $scale text $text radians $radians anchor right
     }
 }
 


### PR DESCRIPTION
This isn't quite correct for multiline strings, but neither was the original code (the text is left-aligned but the whole block is centered on the x and y values). Here's an example test program:

```
Wish $this is outlined white

When $this has region /r/ {
  set text "This is a long test sentence\nwith a second line\nand third"

  set angle [region angle $r]

  set r1 [region move $r down [expr {2*25}]px]
  #Wish region $r1 is outlined blue
  set p [region top $r1]
  Wish to draw text with position $p scale 1 text $text halign center radians $angle color blue
  Wish to draw a circle with center $p radius 5 thickness 0 filled true color blue

  set r1 [region move $r down [expr {5*25}]px]
  #Wish region $r1 is outlined green
  set p [region top $r1]
  Wish to draw text with position $p scale 1 text $text halign left radians $angle color green
  Wish to draw a circle with center $p radius 5 thickness 0 filled true color green

  set r1 [region move $r down [expr {8*25}]px]
  #Wish region $r1 is outlined red
  set p [region top $r1]
  Wish to draw text with position $p scale 1 text $text halign right radians $angle color red
  Wish to draw a circle with center $p radius 5 thickness 0 filled true color red
}
```
To be fully correct each individual line needs to be properly aligned.