### PR TITLE
Small hack to allow pointer warping to work

### DIFF
--- a/virtual-programs/points-at.folk
+++ b/virtual-programs/points-at.folk
@@ -1,8 +1,10 @@
 When when /rect/ points /direction/ with length /l/ at /someone/ /lambda/ with environment /e/ {
+  if {[string match "/*" $rect]} { return }
   Wish $rect points $direction with length $l
 }
 
 When when /rect/ points /direction/ at /someone/ /lambda/ with environment /e/ {
+  if {[string match "/*" $rect]} { return }
   Wish $rect points $direction with length 1
 }
 


### PR DESCRIPTION
Otherwise there is a eval error on the When when since the warp uses a statement like

```
When /obj/ points /direction/ with length /l/ at $warp ...
```