### PR TITLE
Clear mailbox of unmatched processes

### DIFF
--- a/lib/peer.tcl
+++ b/lib/peer.tcl
@@ -34,6 +34,10 @@ proc ::peer {process {dieOnDisconnect false}} {
             variable process
             Mailbox::receive $process $::thisProcess
         }
+	proc clear {} {
+            variable process
+            Mailbox::clear $process $::thisProcess
+	}
 
         proc share {shareStatements} {
             variable process

--- a/lib/process.tcl
+++ b/lib/process.tcl
@@ -115,6 +115,8 @@ proc Start-process {name body} {
             }
         }
         On unmatch {
+	    # Clear the mailbox
+            ::Peers::${name}::clear
             # Remember to suppress/kill the process if it shows up
             # later after we're gone.
             dict set ::peersBlacklist $name true

--- a/main.tcl
+++ b/main.tcl
@@ -556,6 +556,14 @@ namespace eval ::Mailbox {
         } pthread_mutex_unlock(&mailbox->mutex);
         return ret;
     }
+    $cc proc clear {char* from char* to} void {
+        mailbox_t* mailbox = find(from, to);
+        pthread_mutex_lock(&mailbox->mutex); {
+            mailbox->active = 0;
+            mailbox->mail[0] = '\0';
+            mailbox->mailLen = 0;
+        } pthread_mutex_unlock(&mailbox->mutex);
+    }
     $cc compile
     init
 }


### PR DESCRIPTION
This solves the problem of ghost statements from killed processes.