### PR TITLE
Fix mem overflow in mailbox code - snprintf returns the number of characters that could have been written

### DIFF
--- a/main.tcl
+++ b/main.tcl
@@ -546,7 +546,12 @@ namespace eval ::Mailbox {
         }
         pthread_mutex_lock(&mailbox->mutex); {
             int written = snprintf(mailbox->mail, sizeof(mailbox->mail), "%s", statements);
-	    if (written > MAILBOXSIZE) { written = MAILBOXSIZE; }
+	    if (written > MAILBOXSIZE) {
+                fprintf(stderr, "WARNING: Mailbox %s -> %s: "
+                        "Mailbox overflow (%d bytes, MAILBOXSIZE = %d bytes)\n",
+                        from, to, written, MAILBOXSIZE);
+                written = MAILBOXSIZE;
+            }
 	    mailbox->mailLen = written;
         } pthread_mutex_unlock(&mailbox->mutex);
     }


### PR DESCRIPTION
From the docs (https://cplusplus.com/reference/cstdio/snprintf/) - 

"If the resulting string would be longer than n-1 characters, the remaining characters are discarded and not stored, **but counted for the value returned by the function**."