### PR TITLE
Add rgb, hsl, & hex as color formats

### DIFF
--- a/pi/Colors.tcl
+++ b/pi/Colors.tcl
@@ -204,7 +204,7 @@ proc hslToRgb {h s l} {
     return [list $r $g $b]
 }
 
-proc globalColorFunction {color} {
+proc ::getColor {color} {
     if {[info exists Colors::$color]} { return [set Colors::$color] }
     
     if {[regexp {hsl\((\d+),(\d+)%,(\d+)%\)} $color -> h s l]} {

--- a/virtual-programs/display.folk
+++ b/virtual-programs/display.folk
@@ -1,7 +1,4 @@
 source "pi/Colors.tcl"
-proc ::getColor {color} {
-    globalColorFunction $color
-}
 
 proc Start-display-process {code} {
     if {$::tcl_platform(os) eq "Darwin"} {
@@ -85,9 +82,6 @@ Start-display-process {
     }]
 
     source "pi/Colors.tcl"
-    proc ::getColor {color} {
-        globalColorFunction $color
-    }
 
     Wish $::thisProcess receives statements like \
         [list /someone/ wishes the GPU /...anything/]


### PR DESCRIPTION
I've modified the Colors namespace to put all the color logic in `Colors.tcl` and support the following formats for colors:

- `0xNNN` or `0xNNNNNN`
- `rgb(N,N,N)`
- `hsl(N,N%,N%)`

Here's a fun sample program using the new capabilities:

```tcl
When the clock time is /t/ {
    for {set i 0} {$i < 36} {incr i} {
    Wish $this draws a circle with color hsl([expr {$i * 10 + round(sin($t) * 200)}],100%,50%) filled true radius 10 offset [list [* $i -20] 0]

    Wish $this draws a circle with color rgb([* $i 10],0,0) filled true radius 10 offset [list [* $i -20] 30]

    Wish $this draws a circle with color 0xC0E filled true radius 10 offset [list [* $i -20] 60]
    }
}
```
![IMG_5343 2](https://github.com/FolkComputer/folk/assets/5826638/24f22706-0a71-4075-a1a7-7a724b8f6d48)
