### PR TITLE
Use correct function to generate apriltag for ps when printing

### DIFF
--- a/virtual-programs/print.folk
+++ b/virtual-programs/print.folk
@@ -110,7 +110,7 @@ proc ::programToPs {id text {format "letter"} {side "front"}} {
     set tagwidth 150; set tagheight 150
     set fontsize 12; set lineheight [expr $fontsize*1.5]
 
-    set image [::tagImageForId $id]
+    set image [::tagPsForId $id]
 
     set lines [split $text "\n"]
     for {set i 0} {$i < [llength $lines]} {incr i} {


### PR DESCRIPTION
The commit https://github.com/FolkComputer/folk/commit/b7491c42f2d802b0a184e173ed21571f79fca0eb renamed the original `tagImageForId` to `tagPsForId` and created a new definition for `tagImageForId. The code that generates the `.ps` file for printing should rely on the original behavior, so it needs to point to `tagPsForId` as well.