### PR TITLE
Wish to allow program forwarding

### DIFF
--- a/virtual-programs/programs.folk
+++ b/virtual-programs/programs.folk
@@ -29,3 +29,7 @@ When (non-capturing) /type/ /obj/ has a program {
         puts stderr "No code for $type $obj"
     }
 }
+
+When /someone/ wishes /obj/ runs program /code/ {
+  Claim $obj has program code $code
+}


### PR DESCRIPTION
I'm trying to implement "Run this program on that" and using a wish seems nicer than a claim:
```
When $this points up with length 2 at /source/ & \
  /source/ has program code /code/ & \
  $this points down with length 2 at /target/ {

  Wish $this is titled "Active"

  Wish $target runs program $code
}
```