### PR TITLE
Introduce vp/keyboard-shortcuts.folk

### DIFF
--- a/hosts.tcl
+++ b/hosts.tcl
@@ -22,7 +22,7 @@ if {[info exists ::env(FOLK_SHARE_NODE)]} {
         if {$wifi eq "cynosure"} {
             set ::shareNode "folk-omar.local"
         } elseif {$wifi eq "Verizon_TWRHB4" || $wifi eq "nyu"} {
-            set ::shareNode "folk-cwe.local"
+            set ::shareNode "gadget-red.local"
         } elseif {$wifi eq "WONDERLAND"} {
             set ::shareNode "folk-haip.local"
         } elseif {$wifi eq "GETNEAR"} {

--- a/virtual-programs/esc-restart.folk
+++ b/virtual-programs/esc-restart.folk
@@ -1,8 +1,0 @@
-When keyboard /k/ claims key Meta_Escape is down with timestamp /any/ {
-	# When sudo is removed here you get:
-	# 
-	# Error in virtual-programs/esc-restart.folk, match m10029:6: Failed to restart folk.service: Interactive authentication required.
-	# 
-	# TODO: Figure out how to do this with less powerful permissions than `sudo`.
-	exec sudo systemctl restart folk
-}

--- a/virtual-programs/keyboard-shortcuts.folk
+++ b/virtual-programs/keyboard-shortcuts.folk
@@ -1,0 +1,22 @@
+# When sudo is removed in the exec commands below you get:
+# Error in virtual-programs/keyboard-shortcuts.folk, match m10029:6: Failed to restart folk.service: Interactive authentication required.
+#
+# TODO: Figure out how to do this with less powerful permissions than `sudo`. (@cwervo)
+
+# Keyboard shortcuts
+# ---
+#  Alt + Esc: Restart Folk
+#  Shift + Esc: Stop Folk completely (note: need to ssh to restart Folk)
+
+When keyboard /k/ claims key Meta_Escape is down with timestamp /any/ {
+	puts "==== Folk restarting ... ===="
+	exec sudo systemctl restart folk
+}
+
+When keyboard /k/ claims key F1 is down with timestamp /any/ {
+	puts "==== Stoping Folk. ===="
+	puts "===="
+	puts "     Run `make sync-restart` on your laptop or SSH into [info hostname] to restart Folk ===="
+	puts "===="
+	exec sudo systemctl stop folk
+}

--- a/virtual-programs/keyboard-shortcuts.folk
+++ b/virtual-programs/keyboard-shortcuts.folk
@@ -6,14 +6,21 @@
 # Keyboard shortcuts
 # ---
 #  Alt + Esc: Restart Folk
-#  Shift + Esc: Stop Folk completely (note: need to ssh to restart Folk)
+#  Alt + F1: Stop Folk completely (note: need to ssh to restart Folk)
+Claim keyboard debugger is off
 
+When keyboard debugger is on & keyboard /keyboard/ claims key /key/ is down with timestamp /timestamp/ {
+  puts "\[keyboard debugger:\] $key @ $timestamp"
+}
+
+# Alt-Esc on most keyboards
 When keyboard /k/ claims key Meta_Escape is down with timestamp /any/ {
 	puts "==== Folk restarting ... ===="
 	exec sudo systemctl restart folk
 }
 
-When keyboard /k/ claims key F1 is down with timestamp /any/ {
+# Console_1 corresponds to Alt-F1 on most keyboards
+When keyboard /k/ claims key Console_1 is down with timestamp /any/ {
 	puts "==== Stoping Folk. ===="
 	puts "===="
 	puts "     Run `make sync-restart` on your laptop or SSH into [info hostname] to restart Folk ===="


### PR DESCRIPTION
Instead of having the narrow `esc-restart.folk` this adds `keyboard-shortcuts.folk` and implements:
- `Alt` + `Esc` to restart Folk
- `F1` to stop Folk completely

## Feedback I'd like
- Do these mappings make sense?

——-
- Addresses #172 