### PR TITLE
Remove the self-wish for neighbors on the virtual page

### DIFF
--- a/virtual-programs/intersect.folk
+++ b/virtual-programs/intersect.folk
@@ -1,10 +1,3 @@
-#Wish $this is outlined white
-
-When $this has neighbor /n/ {
-  Wish $this is labelled $n
-}
-
-#Wish $this has neighbors
 
 When /someone/ wishes /p/ has neighbors & /p/ has region /r/ & /p2/ has region /r2/ {
   if {$p eq $p2} { return }


### PR DESCRIPTION
This was causing issues when trying to 'realize' all the virtual pages on the table (since I was laying them out in list and the self-wish was causing labelling issues around the intersect.folk virtual region)