### PR TITLE
Pi camera (libcamera) backend; C++ support; subprocess death reporting on stderr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,5 @@
 start:
-	case "$(shell hostname)" in \
-	gadget-*) \
-		libcamerify tclsh8.6 main.tcl;; \
-	*) \
-		tclsh8.6 main.tcl;; \
-	esac
+	tclsh8.6 main.tcl
 debug:
 	gdb --args tclsh8.6 main.tcl
 remote-debug: sync

--- a/lib/c.tcl
+++ b/lib/c.tcl
@@ -100,8 +100,8 @@ namespace eval c {
                 size_t { expr {{ size_t $argname; __ENSURE_OK(Tcl_GetLongFromObj(interp, $obj, (long *)&$argname)); }}}
                 intptr_t { expr {{ intptr_t $argname; __ENSURE_OK(Tcl_GetLongFromObj(interp, $obj, (long *)&$argname)); }}}
                 uint16_t { expr {{ uint16_t $argname; __ENSURE_OK(Tcl_GetIntFromObj(interp, $obj, (int *)&$argname)); }}}
-                uint32_t { expr {{ uint32_t $argname; __ENSURE(sscanf(Tcl_GetString($obj), "%"PRIu32, &$argname) == 1); }}}
-                uint64_t { expr {{ uint64_t $argname; __ENSURE(sscanf(Tcl_GetString($obj), "%"PRIu64, &$argname) == 1); }}}
+                uint32_t { expr {{ uint32_t $argname; __ENSURE(sscanf(Tcl_GetString($obj), "%" PRIu32, &$argname) == 1); }}}
+                uint64_t { expr {{ uint64_t $argname; __ENSURE(sscanf(Tcl_GetString($obj), "%" PRIu64, &$argname) == 1); }}}
                 char* { expr {{ char* $argname = Tcl_GetString($obj); }} }
                 Tcl_Obj* { expr {{ Tcl_Obj* $argname = $obj; }}}
                 default {
@@ -301,7 +301,7 @@ namespace eval c {
                         memcpy(dupPtr->internalRep.ptrAndLongRep.ptr, srcPtr->internalRep.ptrAndLongRep.ptr, sizeof($type));
                     }
                     void $[set type]_updateStringProc(Tcl_Obj *objPtr) {
-                        $[set type] *robj = objPtr->internalRep.ptrAndLongRep.ptr;
+                        $[set type] *robj = ($[set type] *)objPtr->internalRep.ptrAndLongRep.ptr;
 
                         const char *format = "$[join [lmap fieldname $fieldnames {
                             subst {$fieldname {%s}}
@@ -313,7 +313,7 @@ namespace eval c {
                             }
                         }] "\n"]
                         objPtr->length = snprintf(NULL, 0, format, $[join [lmap fieldname $fieldnames {expr {"Tcl_GetString(robj_$fieldname)"}}] ", "]);
-                        objPtr->bytes = ckalloc(objPtr->length + 1);
+                        objPtr->bytes = (char *)ckalloc(objPtr->length + 1);
                         snprintf(objPtr->bytes, objPtr->length + 1, format, $[join [lmap fieldname $fieldnames {expr {"Tcl_GetString(robj_$fieldname)"}}] ", "]);
                     }
                     int $[set type]_setFromAnyProc(Tcl_Interp *interp, Tcl_Obj *objPtr) {

--- a/lib/process.tcl
+++ b/lib/process.tcl
@@ -1,8 +1,11 @@
 namespace eval ::Zygote {
     set cc [c create]
     $cc include <unistd.h>
+    $cc include <sys/wait.h>
     $cc proc ::Zygote::fork {} int { return fork(); }
-    # FIXME: waitpid
+    $cc proc ::Zygote::wait {} int {
+        return wait(NULL);
+    }
     # FIXME: some kind of shared-memory log queue
     $cc compile
 
@@ -89,18 +92,22 @@ proc Start-process {name body} {
 
     ::peer $name false
 
-    Zygote::spawn [list apply {{processCode} {
+    Zygote::spawn [list apply {{processName processCode} {
         # A supervisor that wraps the subprocess.
         set pid [Zygote::fork]
         if {$pid == 0} {
             eval $processCode
         } else {
-            # TODO: Supervise the subprocess.
-            # waitpid $pid
-            # how to report outcomes to Folk?
+            set deadPid [Zygote::wait]
+            if {$deadPid == $pid} {
+                puts stderr "process: Subprocess '$processName' ($pid) died!"
+            } else {
+                error "process: Unknown pid $deadPid died."
+            }
+            # TODO: how to report outcomes to Folk?
             # does it have an inbox? do we assert into Folk and let it retract?
         }
-    }} $processCode]
+    }} $name $processCode]
 
     # Wrap these in a new scope so they don't capture a bunch of
     # random stuff from this outer scope.

--- a/test/cpp.tcl
+++ b/test/cpp.tcl
@@ -1,0 +1,12 @@
+set cpp [C++]
+$cpp include <vector>
+$cpp proc addInCpp {int a int b} int {
+    std::vector<int> xs = {a, b};
+    int sum = 0;
+    for (int x : xs) {
+        sum += x;
+    }
+    return sum;
+}
+$cpp compile
+puts "10 + 3 = [addInCpp 10 3]"

--- a/virtual-programs/apriltags.folk
+++ b/virtual-programs/apriltags.folk
@@ -1,5 +1,3 @@
-if {$::isLaptop} return
-
 set makeAprilTagDetector {{TAG_FAMILY} {
     set detector AprilTagDetector_${TAG_FAMILY}
     namespace eval $detector {

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -5,11 +5,14 @@ set makeCamera {
     $cpp include <iostream>
     $cpp include <iomanip>
     $cpp include <atomic>
+    $cpp include <sys/mman.h>
+
     $cpp include <libcamera/libcamera.h>
     # osnr: HACK: because I'm building libcamera locally for now.
     $cpp cflags -I/usr/local/include/libcamera
     c loadlibLd libcamera
 
+    defineImageType $cpp
     $cpp code {
         using namespace libcamera;
 
@@ -22,6 +25,10 @@ set makeCamera {
 	std::vector<std::unique_ptr<Request>> requests;
 
         std::atomic<Request *> latestRequest;
+
+        uint32_t frameWidth;
+        uint32_t frameHeight;
+        uint32_t frameBytesPerRow;
 
         static void requestComplete(Request *request);
     }
@@ -40,6 +47,10 @@ set makeCamera {
         config = camera->generateConfiguration({ StreamRole::Viewfinder });
         StreamConfiguration &streamConfig = config->at(0);
         config->validate();
+        frameWidth = streamConfig.size.width;
+        frameHeight = streamConfig.size.height;
+        frameBytesPerRow = streamConfig.stride;
+
 	camera->configure(config.get());
 
         allocator = new FrameBufferAllocator(camera);
@@ -54,6 +65,8 @@ set makeCamera {
 	}
 
         Stream *stream = streamConfig.stream();
+        assert(streamConfig.pixelFormat.toString() == "XRGB8888");
+
         const std::vector<std::unique_ptr<FrameBuffer>> &buffers = allocator->buffers(stream);
 	for (unsigned int i = 0; i < buffers.size(); ++i) {
 		std::unique_ptr<Request> request = camera->createRequest();
@@ -90,6 +103,8 @@ set makeCamera {
 		return;
             }
 
+            printf("======== REQUEST COMPLETE========\n");
+
             Request *prevLatestRequest;
             do {
                 prevLatestRequest = latestRequest;
@@ -102,10 +117,29 @@ set makeCamera {
             }
         }
 
-        static void processRequest(Request *request) {
-            printf("processRequest (%p)\n", request);
-            std::cout << std::endl
-                      << "Request completed: " << request->toString() << std::endl;
+        static void imageCopyGray(image_t to, image_t from) {
+            FOLK_ENSURE(from.components == 4);
+            FOLK_ENSURE(from.width == to.width);
+            FOLK_ENSURE(from.height == to.height);
+
+            for (uint32_t y = 0; y < from.height; y++) {
+                for (uint32_t x = 0; x < from.width; x++) {
+                    uint32_t i = (y * from.bytesPerRow) + x * 4;
+                    // FIXME: XRGB8888 assumed
+                    uint32_t r = from.data[i + 1];
+                    uint32_t g = from.data[i + 2];
+                    uint32_t b = from.data[i + 3];
+                    // from https://mina86.com/2021/rgb-to-greyscale/
+                    uint32_t yy = 3567664 * r + 11998547 * g + 1211005 * b;
+                    to.data[y * to.bytesPerRow + x] = ((yy + (1 << 23)) >> 24);
+                }
+            }
+        }
+
+        static void processRequestAndCopyFrame(Request *request, image_t im) {
+            // printf("processRequest (%p)\n", request);
+            // std::cout << std::endl
+            //           << "Request completed: " << request->toString() << std::endl;
 
             /*
              * When a request has completed, it is populated with a metadata control
@@ -118,14 +152,14 @@ set makeCamera {
              * all the metadata for inspection. A custom application can parse each
              * of these items and process them according to its needs.
              */
-            const ControlList &requestMetadata = request->metadata();
-            for (const auto &ctrl : requestMetadata) {
-                    const ControlId *id = controls::controls.at(ctrl.first);
-                    const ControlValue &value = ctrl.second;
+            // const ControlList &requestMetadata = request->metadata();
+            // for (const auto &ctrl : requestMetadata) {
+            //         const ControlId *id = controls::controls.at(ctrl.first);
+            //         const ControlValue &value = ctrl.second;
 
-                    std::cout << "\t" << id->name() << " = " << value.toString()
-                              << std::endl;
-            }
+            //         // std::cout << "\t" << id->name() << " = " << value.toString()
+            //         //           << std::endl;
+            // }
 
             /*
              * Each buffer has its own FrameMetadata to describe its state, or the
@@ -138,30 +172,46 @@ set makeCamera {
              * sensor along with the image as processed by the ISP.
              */
             const Request::BufferMap &buffers = request->buffers();
+            assert(buffers.size() == 1);
             for (auto bufferPair : buffers) {
                     // (Unused) Stream *stream = bufferPair.first;
                     FrameBuffer *buffer = bufferPair.second;
                     const FrameMetadata &metadata = buffer->metadata();
 
                     /* Print some information about the buffer which has completed. */
-                    std::cout << " seq: " << std::setw(6) << std::setfill('0') << metadata.sequence
-                              << " timestamp: " << metadata.timestamp
-                              << " bytesused: ";
+                    // std::cout << " seq: " << std::setw(6) << std::setfill('0') << metadata.sequence
+                    //           << " timestamp: " << metadata.timestamp
+                    //           << " bytesused: ";
 
-                    unsigned int nplane = 0;
-                    for (const FrameMetadata::Plane &plane : metadata.planes())
-                    {
-                            std::cout << plane.bytesused;
-                            if (++nplane < metadata.planes().size())
-                                    std::cout << "/";
-                    }
-
-                    std::cout << std::endl;
-
+                    // unsigned int nplane = 0;
+                    // for (const FrameMetadata::Plane &plane : metadata.planes())
+                    // {
+                    //         std::cout << plane.bytesused;
+                    //         if (++nplane < metadata.planes().size())
+                    //                 std::cout << "/";
+                    // }
+                    assert(metadata.planes().size() == 1);
+                    assert(buffer->planes().size() == 1);
+                    
+                    auto &plane = buffer->planes()[0];
+                    int fd = plane.fd.get();
+                    
                     /*
                      * Image data can be accessed here, but the FrameBuffer
                      * must be mapped by the application
                      */
+                    void *addr = mmap64(NULL, plane.length, PROT_READ, MAP_PRIVATE, fd, 0);
+                    if (addr == MAP_FAILED) {
+                        FOLK_ERROR("camera-rpi: MAP_FAILED");
+                    }
+                    void *planeData = (uint8_t *)addr + plane.offset;
+                    image_t planeIm = {
+                        .width = frameWidth, .height = frameHeight,
+                        .components = 4, .bytesPerRow = frameBytesPerRow,
+                        .data = (uint8_t *)planeData
+                    };
+                    imageCopyGray(im, planeIm);
+                    munmap(addr, plane.length);
             }
 
             /* Re-queue the Request to the camera. */
@@ -170,13 +220,12 @@ set makeCamera {
         }
     }
 
-    defineImageType $cpp
     $cpp import ::Heap::cc folkHeapAlloc as folkHeapAlloc
     $cpp import ::Heap::cc folkHeapFree as folkHeapFree
 
     $cpp proc newImage {} image_t {
-        uint32_t width = 1280;
-        uint32_t height = 720;
+        uint32_t width = frameWidth;
+        uint32_t height = frameHeight;
         int components = 1;
         uint8_t *data = (uint8_t *)folkHeapAlloc(width*components*height);
         return (image_t) {
@@ -192,18 +241,17 @@ set makeCamera {
     }
 
     $cpp proc grayFrame {} image_t {
-        image_t im = newImage();
-
         // We want to take exclusive ownership over the request.
         Request *request;
         do {
             request = latestRequest;
         } while (!latestRequest.compare_exchange_weak(request, nullptr));
 
-        if (request != nullptr) {
-            processRequest(request);
-        }
+        if (request == nullptr) { FOLK_ERROR("No new frame yet"); }
 
+        image_t im = newImage();
+        processRequestAndCopyFrame(request, im);
+        printf("Got new frame\n");
         return im;
     }
 
@@ -231,7 +279,10 @@ When /someone/ wishes $::thisNode uses camera /cameraPath/ with /...options/ {
 
         set ::oldFrames [list]
         When $::thisProcess has step count /c/ {
-            set frame [Camera::grayFrame]
+            try {
+                set frame [Camera::grayFrame]
+            } on error e { return }
+
             Hold {
                 Claim camera $cameraPath has camera time $::stepTime
                 Claim camera $cameraPath has frame $frame at timestamp [expr {[clock milliseconds] / 1000.0}]

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -4,7 +4,7 @@ set makeCamera {
     set cpp [C++]
     $cpp include <iostream>
     $cpp include <iomanip>
-    $cpp include <atomic>
+    $cpp include <mutex>
     $cpp include <sys/mman.h>
 
     $cpp include <libcamera/libcamera.h>
@@ -24,7 +24,8 @@ set makeCamera {
         // This vector always owns all the request objects.
 	std::vector<std::unique_ptr<Request>> requests;
 
-        std::atomic<Request *> latestRequest;
+        std::mutex latestRequestMutex;
+        Request *latestRequest;
 
         uint32_t frameWidth;
         uint32_t frameHeight;
@@ -101,19 +102,23 @@ set makeCamera {
     $cpp code {
         static void requestComplete(Request *request) {
             if (request->status() == Request::RequestCancelled) {
+                std::cout << "Request cancelled: " << request << std::endl;
 		return;
             }
 
-            printf("======== REQUEST COMPLETE========\n");
+            std::cout << "======== REQUEST COMPLETE: " << request << std::endl;
 
-            Request *prevLatestRequest;
-            do {
-                prevLatestRequest = latestRequest;
-            } while (!latestRequest.compare_exchange_weak(prevLatestRequest, request));
+            latestRequestMutex.lock();
+
+            Request *prevLatestRequest = latestRequest;
+            latestRequest = request;
+
+            latestRequestMutex.unlock();
 
             if (prevLatestRequest != nullptr) {
                 // Re-dispatch this request that we're skipping.
                 request->reuse(Request::ReuseBuffers);
+                std::cout << "Requeue from requestComplete: " << request << std::endl;
                 camera->queueRequest(request);
             }
         }
@@ -217,6 +222,7 @@ set makeCamera {
 
             /* Re-queue the Request to the camera. */
             request->reuse(Request::ReuseBuffers);
+            std::cout << "Requeue from processRequestAndCopyFrame: " << request << std::endl;
             camera->queueRequest(request);
         }
     }
@@ -244,9 +250,12 @@ set makeCamera {
     $cpp proc grayFrame {} image_t {
         // We want to take exclusive ownership over the request.
         Request *request;
-        do {
-            request = latestRequest;
-        } while (!latestRequest.compare_exchange_weak(request, nullptr));
+        latestRequestMutex.lock();
+
+        request = latestRequest;
+        latestRequest = nullptr;
+
+        latestRequestMutex.unlock();
 
         if (request == nullptr) { FOLK_ERROR("No new frame yet"); }
 

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -9,8 +9,8 @@ set makeCamera {
     $cpp include <sys/mman.h>
 
     $cpp include <libcamera/libcamera.h>
-    # osnr: HACK: because I'm building libcamera locally for now.
-    $cpp cflags -I/usr/local/include/libcamera
+    # osnr: HACK: just throwing any possible path in.
+    $cpp cflags -I/usr/local/include/libcamera -I/usr/include/libcamera
     c loadlibLd libcamera
 
     defineImageType $cpp
@@ -111,7 +111,7 @@ set makeCamera {
             completedRequestsMutex.unlock();
         }
 
-        static void imageCopyGray(image_t to, image_t from) {
+        static void imageCopyRgb(image_t to, image_t from) {
             FOLK_ENSURE(from.components == 4);
             FOLK_ENSURE(from.width == to.width);
             FOLK_ENSURE(from.height == to.height);
@@ -120,12 +120,13 @@ set makeCamera {
                 for (uint32_t x = 0; x < from.width; x++) {
                     uint32_t i = (y * from.bytesPerRow) + x * 4;
                     // FIXME: XRGB8888 assumed
-                    uint32_t r = from.data[i + 1];
-                    uint32_t g = from.data[i + 2];
-                    uint32_t b = from.data[i + 3];
+                    uint8_t b = from.data[i + 0];
+                    uint8_t g = from.data[i + 1];
+                    uint8_t r = from.data[i + 2];
                     // from https://mina86.com/2021/rgb-to-greyscale/
-                    uint32_t yy = 3567664 * r + 11998547 * g + 1211005 * b;
-                    to.data[y * to.bytesPerRow + x] = ((yy + (1 << 23)) >> 24);
+                    to.data[y * to.bytesPerRow + x*3 + 0] = r;
+                    to.data[y * to.bytesPerRow + x*3 + 1] = g;
+                    to.data[y * to.bytesPerRow + x*3 + 2] = b;
                 }
             }
         }
@@ -204,7 +205,7 @@ set makeCamera {
                         .components = 4, .bytesPerRow = frameBytesPerRow,
                         .data = (uint8_t *)planeData
                     };
-                    imageCopyGray(im, planeIm);
+                    imageCopyRgb(im, planeIm);
                     munmap(addr, plane.length);
             }
         }
@@ -216,7 +217,7 @@ set makeCamera {
     $cpp proc newImage {} image_t {
         uint32_t width = frameWidth;
         uint32_t height = frameHeight;
-        int components = 1;
+        int components = 3;
         uint8_t *data = (uint8_t *)folkHeapAlloc(width*components*height);
         return (image_t) {
             .width = width,

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -65,6 +65,13 @@ set makeCamera {
 
             size_t allocated = allocator->buffers(cfg.stream()).size();
             std::cout << "camera-rpi: Allocated " << allocated << " buffers for stream" << std::endl;
+
+            for (PixelFormat &format : cfg.formats().pixelformats()) {
+                std::cout << "camera-rpi: Stream supports format " << format << std::endl;
+                // for (Size &size : cfg.formats().sizes(format)) {
+                //     std::cout << "  -> supports size " << size << std::endl;
+                // }
+            }
 	}
 
         Stream *stream = streamConfig.stream();
@@ -111,8 +118,27 @@ set makeCamera {
             completedRequestsMutex.unlock();
         }
 
-        static void imageCopyRgb(image_t to, image_t from) {
+        // static void imageCopyRgb(image_t to, image_t from) {
+        //     FOLK_ENSURE(from.components == 4);
+        //     FOLK_ENSURE(from.width == to.width);
+        //     FOLK_ENSURE(from.height == to.height);
+
+        //     for (uint32_t y = 0; y < from.height; y++) {
+        //         for (uint32_t x = 0; x < from.width; x++) {
+        //             uint32_t i = (y * from.bytesPerRow) + x * 4;
+        //             // FIXME: XRGB8888 assumed
+        //             uint8_t b = from.data[i + 0];
+        //             uint8_t g = from.data[i + 1];
+        //             uint8_t r = from.data[i + 2];
+        //             to.data[y * to.bytesPerRow + x*3 + 0] = r;
+        //             to.data[y * to.bytesPerRow + x*3 + 1] = g;
+        //             to.data[y * to.bytesPerRow + x*3 + 2] = b;
+        //         }
+        //     }
+        // }
+        static void imageCopyGray(image_t to, image_t from) {
             FOLK_ENSURE(from.components == 4);
+            FOLK_ENSURE(to.components == 1);
             FOLK_ENSURE(from.width == to.width);
             FOLK_ENSURE(from.height == to.height);
 
@@ -120,13 +146,12 @@ set makeCamera {
                 for (uint32_t x = 0; x < from.width; x++) {
                     uint32_t i = (y * from.bytesPerRow) + x * 4;
                     // FIXME: XRGB8888 assumed
-                    uint8_t b = from.data[i + 0];
-                    uint8_t g = from.data[i + 1];
-                    uint8_t r = from.data[i + 2];
+                    uint32_t b = from.data[i + 0];
+                    uint32_t g = from.data[i + 1];
+                    uint32_t r = from.data[i + 2];
                     // from https://mina86.com/2021/rgb-to-greyscale/
-                    to.data[y * to.bytesPerRow + x*3 + 0] = r;
-                    to.data[y * to.bytesPerRow + x*3 + 1] = g;
-                    to.data[y * to.bytesPerRow + x*3 + 2] = b;
+                    uint32_t yy = 3567664 * r + 11998547 * g + 1211005 * b;
+                    to.data[y * to.bytesPerRow + x] = ((yy + (1 << 23)) >> 24);
                 }
             }
         }
@@ -205,7 +230,7 @@ set makeCamera {
                         .components = 4, .bytesPerRow = frameBytesPerRow,
                         .data = (uint8_t *)planeData
                     };
-                    imageCopyRgb(im, planeIm);
+                    imageCopyGray(im, planeIm);
                     munmap(addr, plane.length);
             }
         }
@@ -217,7 +242,7 @@ set makeCamera {
     $cpp proc newImage {} image_t {
         uint32_t width = frameWidth;
         uint32_t height = frameHeight;
-        int components = 3;
+        int components = 1;
         uint8_t *data = (uint8_t *)folkHeapAlloc(width*components*height);
         return (image_t) {
             .width = width,

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -69,12 +69,12 @@ set makeCamera {
             size_t allocated = allocator->buffers(cfg.stream()).size();
             std::cout << "camera-rpi: Allocated " << allocated << " buffers for stream" << std::endl;
 
-            for (PixelFormat &format : cfg.formats().pixelformats()) {
-                std::cout << "camera-rpi: Stream supports format " << format << std::endl;
+            // for (PixelFormat &format : cfg.formats().pixelformats()) {
+                // std::cout << "camera-rpi: Stream supports format " << format << std::endl;
                 // for (Size &size : cfg.formats().sizes(format)) {
                 //     std::cout << "  -> supports size " << size << std::endl;
                 // }
-            }
+            // }
 	}
 
         Stream *stream = streamConfig.stream();
@@ -154,10 +154,6 @@ set makeCamera {
         }
 
         static void processRequestAndCopyFrame(Request *request, image_t im) {
-            // printf("processRequest (%p)\n", request);
-            // std::cout << std::endl
-            //           << "Request completed: " << request->toString() << std::endl;
-
             /*
              * When a request has completed, it is populated with a metadata control
              * list that allows an application to determine various properties of
@@ -174,20 +170,10 @@ set makeCamera {
             //         const ControlId *id = controls::controls.at(ctrl.first);
             //         const ControlValue &value = ctrl.second;
 
-            //         // std::cout << "\t" << id->name() << " = " << value.toString()
-            //         //           << std::endl;
+            //         std::cout << "\t" << id->name() << " = " << value.toString()
+            //                   << std::endl;
             // }
 
-            /*
-             * Each buffer has its own FrameMetadata to describe its state, or the
-             * usage of each buffer. While in our simple capture we only provide one
-             * buffer per request, a request can have a buffer for each stream that
-             * is established when configuring the camera.
-             *
-             * This allows a viewfinder and a still image to be processed at the
-             * same time, or to allow obtaining the RAW capture buffer from the
-             * sensor along with the image as processed by the ISP.
-             */
             const Request::BufferMap &buffers = request->buffers();
             assert(buffers.size() == 1);
             for (auto bufferPair : buffers) {
@@ -195,28 +181,12 @@ set makeCamera {
                     FrameBuffer *buffer = bufferPair.second;
                     const FrameMetadata &metadata = buffer->metadata();
 
-                    /* Print some information about the buffer which has completed. */
-                    // std::cout << " seq: " << std::setw(6) << std::setfill('0') << metadata.sequence
-                    //           << " timestamp: " << metadata.timestamp
-                    //           << " bytesused: ";
-
-                    // unsigned int nplane = 0;
-                    // for (const FrameMetadata::Plane &plane : metadata.planes())
-                    // {
-                    //         std::cout << plane.bytesused;
-                    //         if (++nplane < metadata.planes().size())
-                    //                 std::cout << "/";
-                    // }
                     assert(metadata.planes().size() == 1);
                     assert(buffer->planes().size() == 1);
                     
                     auto &plane = buffer->planes()[0];
                     int fd = plane.fd.get();
-                    
-                    /*
-                     * Image data can be accessed here, but the FrameBuffer
-                     * must be mapped by the application
-                     */
+
                     void *addr = mmap64(NULL, plane.length, PROT_READ, MAP_PRIVATE, fd, 0);
                     if (addr == MAP_FAILED) {
                         FOLK_ERROR("camera-rpi: MAP_FAILED");

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -93,12 +93,6 @@ set makeCamera {
                     FOLK_ERROR("camera-rpi: Can't set buffer for request");
 		}
 
-		/*
-		 * Controls can be added to a request on a per frame basis.
-		 */
-		ControlList &controls = request->controls();
-		controls.set(controls::Brightness, 0.5);
-
 		requests.push_back(std::move(request));
 	}
 

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -5,6 +5,7 @@ set makeCamera {
     $cpp include <iostream>
     $cpp include <iomanip>
     $cpp include <mutex>
+    $cpp include <queue>
     $cpp include <sys/mman.h>
 
     $cpp include <libcamera/libcamera.h>
@@ -24,8 +25,8 @@ set makeCamera {
         // This vector always owns all the request objects.
 	std::vector<std::unique_ptr<Request>> requests;
 
-        std::mutex latestRequestMutex;
-        Request *latestRequest;
+        std::mutex completedRequestsMutex;
+        std::queue<Request *> completedRequests;
 
         uint32_t frameWidth;
         uint32_t frameHeight;
@@ -108,19 +109,9 @@ set makeCamera {
 
             std::cout << "======== REQUEST COMPLETE: " << request << std::endl;
 
-            latestRequestMutex.lock();
-
-            Request *prevLatestRequest = latestRequest;
-            latestRequest = request;
-
-            latestRequestMutex.unlock();
-
-            if (prevLatestRequest != nullptr) {
-                // Re-dispatch this request that we're skipping.
-                request->reuse(Request::ReuseBuffers);
-                std::cout << "Requeue from requestComplete: " << request << std::endl;
-                camera->queueRequest(request);
-            }
+            completedRequestsMutex.lock();
+            completedRequests.push(request);
+            completedRequestsMutex.unlock();
         }
 
         static void imageCopyGray(image_t to, image_t from) {
@@ -219,11 +210,6 @@ set makeCamera {
                     imageCopyGray(im, planeIm);
                     munmap(addr, plane.length);
             }
-
-            /* Re-queue the Request to the camera. */
-            request->reuse(Request::ReuseBuffers);
-            std::cout << "Requeue from processRequestAndCopyFrame: " << request << std::endl;
-            camera->queueRequest(request);
         }
     }
 
@@ -248,20 +234,34 @@ set makeCamera {
     }
 
     $cpp proc grayFrame {} image_t {
-        // We want to take exclusive ownership over the request.
-        Request *request;
-        latestRequestMutex.lock();
+        Request *latestRequest = nullptr;
 
-        request = latestRequest;
-        latestRequest = nullptr;
+        // We want to drain the queue of completed requests.
+        completedRequestsMutex.lock();
+        while (!completedRequests.empty()) {
+            if (latestRequest != nullptr) {
+                // We're skipping this request, because we have a
+                // newer one in the queue. Requeue it.
+                latestRequest->reuse(Request::ReuseBuffers);
+                camera->queueRequest(latestRequest);
+            }
+            latestRequest = completedRequests.front();
+            completedRequests.pop();
+        }
+        completedRequestsMutex.unlock();
 
-        latestRequestMutex.unlock();
-
-        if (request == nullptr) { FOLK_ERROR("No new frame yet"); }
+        if (latestRequest == nullptr) {
+            FOLK_ERROR("No new frame yet");
+        }
 
         image_t im = newImage();
-        processRequestAndCopyFrame(request, im);
+        processRequestAndCopyFrame(latestRequest, im);
         printf("Got new frame\n");
+
+        /* Re-queue the Request to the camera. */
+        latestRequest->reuse(Request::ReuseBuffers);
+        camera->queueRequest(latestRequest);
+
         return im;
     }
 

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -103,11 +103,8 @@ set makeCamera {
     $cpp code {
         static void requestComplete(Request *request) {
             if (request->status() == Request::RequestCancelled) {
-                std::cout << "Request cancelled: " << request << std::endl;
 		return;
             }
-
-            std::cout << "======== REQUEST COMPLETE: " << request << std::endl;
 
             completedRequestsMutex.lock();
             completedRequests.push(request);
@@ -256,7 +253,6 @@ set makeCamera {
 
         image_t im = newImage();
         processRequestAndCopyFrame(latestRequest, im);
-        printf("Got new frame\n");
 
         /* Re-queue the Request to the camera. */
         latestRequest->reuse(Request::ReuseBuffers);

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -48,6 +48,9 @@ set makeCamera {
 
         config = camera->generateConfiguration({ StreamRole::Viewfinder });
         StreamConfiguration &streamConfig = config->at(0);
+        streamConfig.size = Size(width, height);
+        // streamConfig.pixelFormat = PixelFormat.fromString("YUV420");
+
         config->validate();
         frameWidth = streamConfig.size.width;
         frameHeight = streamConfig.size.height;

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -103,6 +103,7 @@ set makeCamera {
         }
 
         static void processRequest(Request *request) {
+            printf("processRequest (%p)\n", request);
             std::cout << std::endl
                       << "Request completed: " << request->toString() << std::endl;
 
@@ -199,9 +200,9 @@ set makeCamera {
             request = latestRequest;
         } while (!latestRequest.compare_exchange_weak(request, nullptr));
 
-        std::cout << "before-processrequest" << std::endl;
-        processRequest(request);
-        std::cout << "after-processrequest" << std::endl;
+        if (request != nullptr) {
+            processRequest(request);
+        }
 
         return im;
     }

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -4,6 +4,7 @@ set makeCamera {
     set cpp [C++]
     $cpp include <iostream>
     $cpp include <iomanip>
+    $cpp include <atomic>
     $cpp include <libcamera/libcamera.h>
     # osnr: HACK: because I'm building libcamera locally for now.
     $cpp cflags -I/usr/local/include/libcamera
@@ -11,49 +12,21 @@ set makeCamera {
 
     $cpp code {
         using namespace libcamera;
+
+        std::unique_ptr<CameraManager> cm;
         std::shared_ptr<Camera> camera;
+	std::unique_ptr<CameraConfiguration> config;
+	FrameBufferAllocator *allocator;
 
-        static void requestComplete(Request *request) {
-            if (request->status() == Request::RequestCancelled) {
-		return;
-            }
+        // This vector always owns all the request objects.
+	std::vector<std::unique_ptr<Request>> requests;
 
-            // TODO: copy the buffer to be managed by Folk and queue it up?
-            // is that too slow?
-            const Request::BufferMap &buffers = request->buffers();
-            for (auto bufferPair : buffers) {
-		// (Unused) Stream *stream = bufferPair.first;
-		FrameBuffer *buffer = bufferPair.second;
-		const FrameMetadata &metadata = buffer->metadata();
+        std::atomic<Request *> latestRequest;
 
-		/* Print some information about the buffer which has completed. */
-		std::cout << " seq: " << std::setw(6) << std::setfill('0') << metadata.sequence
-			  << " timestamp: " << metadata.timestamp
-			  << " bytesused: ";
-
-		unsigned int nplane = 0;
-		for (const FrameMetadata::Plane &plane : metadata.planes())
-                    {
-			std::cout << plane.bytesused;
-			if (++nplane < metadata.planes().size())
-                            std::cout << "/";
-                    }
-
-		std::cout << std::endl;
-
-		/*
-		 * Image data can be accessed here, but the FrameBuffer
-		 * must be mapped by the application
-		 */
-            }
-
-            /* Re-queue the Request to the camera. */
-            request->reuse(Request::ReuseBuffers);
-            camera->queueRequest(request);
-        }
+        static void requestComplete(Request *request);
     }
     $cpp proc cameraOpen {char* id int width int height} void {
-        std::unique_ptr<CameraManager> cm = std::make_unique<CameraManager>();
+        cm = std::make_unique<CameraManager>();
         cm->start();
 
         std::cout << "camera-rpi: cameras:" << std::endl;
@@ -64,13 +37,12 @@ set makeCamera {
         camera = cm->get(id);
         camera->acquire();
 
-	std::unique_ptr<CameraConfiguration> config =
-            camera->generateConfiguration({ StreamRole::Viewfinder });
+        config = camera->generateConfiguration({ StreamRole::Viewfinder });
         StreamConfiguration &streamConfig = config->at(0);
         config->validate();
 	camera->configure(config.get());
 
-	FrameBufferAllocator *allocator = new FrameBufferAllocator(camera);
+        allocator = new FrameBufferAllocator(camera);
 	for (StreamConfiguration &cfg : *config) {
             int ret = allocator->allocate(cfg.stream());
             if (ret < 0) {
@@ -78,25 +50,21 @@ set makeCamera {
             }
 
             size_t allocated = allocator->buffers(cfg.stream()).size();
-            std::cout << "Allocated " << allocated << " buffers for stream" << std::endl;
+            std::cout << "camera-rpi: Allocated " << allocated << " buffers for stream" << std::endl;
 	}
 
         Stream *stream = streamConfig.stream();
-	const std::vector<std::unique_ptr<FrameBuffer>> &buffers = allocator->buffers(stream);
-	std::vector<std::unique_ptr<Request>> requests;
+        const std::vector<std::unique_ptr<FrameBuffer>> &buffers = allocator->buffers(stream);
 	for (unsigned int i = 0; i < buffers.size(); ++i) {
 		std::unique_ptr<Request> request = camera->createRequest();
-		if (!request)
-		{
-                    FOLK_ERROR("Can't create request");
-
+		if (!request) {
+                    FOLK_ERROR("camera-rpi: Can't create request");
 		}
 
 		const std::unique_ptr<FrameBuffer> &buffer = buffers[i];
 		int ret = request->addBuffer(stream, buffer.get());
-		if (ret < 0)
-		{
-                    FOLK_ERROR("Can't set buffer for request");
+		if (ret < 0) {
+                    FOLK_ERROR("camera-rpi: Can't set buffer for request");
 		}
 
 		/*
@@ -113,6 +81,91 @@ set makeCamera {
         camera->start();
 	for (std::unique_ptr<Request> &request : requests) {
             camera->queueRequest(request.get());
+        }
+    }
+
+    $cpp code {
+        static void requestComplete(Request *request) {
+            if (request->status() == Request::RequestCancelled) {
+		return;
+            }
+
+            Request *prevLatestRequest;
+            do {
+                prevLatestRequest = latestRequest;
+            } while (!latestRequest.compare_exchange_weak(prevLatestRequest, request));
+
+            if (prevLatestRequest != nullptr) {
+                // Re-dispatch this request that we're skipping.
+                request->reuse(Request::ReuseBuffers);
+                camera->queueRequest(request);
+            }
+        }
+
+        static void processRequest(Request *request) {
+            std::cout << std::endl
+                      << "Request completed: " << request->toString() << std::endl;
+
+            /*
+             * When a request has completed, it is populated with a metadata control
+             * list that allows an application to determine various properties of
+             * the completed request. This can include the timestamp of the Sensor
+             * capture, or its gain and exposure values, or properties from the IPA
+             * such as the state of the 3A algorithms.
+             *
+             * ControlValue types have a toString, so to examine each request, print
+             * all the metadata for inspection. A custom application can parse each
+             * of these items and process them according to its needs.
+             */
+            const ControlList &requestMetadata = request->metadata();
+            for (const auto &ctrl : requestMetadata) {
+                    const ControlId *id = controls::controls.at(ctrl.first);
+                    const ControlValue &value = ctrl.second;
+
+                    std::cout << "\t" << id->name() << " = " << value.toString()
+                              << std::endl;
+            }
+
+            /*
+             * Each buffer has its own FrameMetadata to describe its state, or the
+             * usage of each buffer. While in our simple capture we only provide one
+             * buffer per request, a request can have a buffer for each stream that
+             * is established when configuring the camera.
+             *
+             * This allows a viewfinder and a still image to be processed at the
+             * same time, or to allow obtaining the RAW capture buffer from the
+             * sensor along with the image as processed by the ISP.
+             */
+            const Request::BufferMap &buffers = request->buffers();
+            for (auto bufferPair : buffers) {
+                    // (Unused) Stream *stream = bufferPair.first;
+                    FrameBuffer *buffer = bufferPair.second;
+                    const FrameMetadata &metadata = buffer->metadata();
+
+                    /* Print some information about the buffer which has completed. */
+                    std::cout << " seq: " << std::setw(6) << std::setfill('0') << metadata.sequence
+                              << " timestamp: " << metadata.timestamp
+                              << " bytesused: ";
+
+                    unsigned int nplane = 0;
+                    for (const FrameMetadata::Plane &plane : metadata.planes())
+                    {
+                            std::cout << plane.bytesused;
+                            if (++nplane < metadata.planes().size())
+                                    std::cout << "/";
+                    }
+
+                    std::cout << std::endl;
+
+                    /*
+                     * Image data can be accessed here, but the FrameBuffer
+                     * must be mapped by the application
+                     */
+            }
+
+            /* Re-queue the Request to the camera. */
+            request->reuse(Request::ReuseBuffers);
+            camera->queueRequest(request);
         }
     }
 
@@ -138,7 +191,19 @@ set makeCamera {
     }
 
     $cpp proc grayFrame {} image_t {
-        return newImage();
+        image_t im = newImage();
+
+        // We want to take exclusive ownership over the request.
+        Request *request;
+        do {
+            request = latestRequest;
+        } while (!latestRequest.compare_exchange_weak(request, nullptr));
+
+        std::cout << "before-processrequest" << std::endl;
+        processRequest(request);
+        std::cout << "after-processrequest" << std::endl;
+
+        return im;
     }
 
     $cpp compile

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -50,6 +50,7 @@ set makeCamera {
         frameWidth = streamConfig.size.width;
         frameHeight = streamConfig.size.height;
         frameBytesPerRow = streamConfig.stride;
+        std::cout << "frameWidth: " << frameWidth << " frameHeight: " << frameHeight << std::endl;
 
 	camera->configure(config.get());
 

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -1,0 +1,76 @@
+if {$::isLaptop} return
+
+set makeCamera {
+    set cpp [C++]
+    $cpp include <iostream>
+    $cpp include <libcamera/libcamera.h>
+    # osnr: HACK: because I'm building libcamera locally for now.
+    $cpp cflags -I/usr/local/include/libcamera
+    c loadlibLd libcamera
+
+    $cpp code {
+        using namespace libcamera;
+        std::shared_ptr<Camera> camera;
+    }
+    $cpp proc cameraOpen {char* id int width int height} void {
+        std::unique_ptr<CameraManager> cm = std::make_unique<CameraManager>();
+        cm->start();
+
+        std::cout << "camera-rpi: cameras:" << std::endl;
+	for (auto const &camera : cm->cameras()) {
+            std::cout << " - " << camera->id() << std::endl;
+        }
+
+        camera = cm->get(id);
+        camera->acquire();
+
+	/* std::unique_ptr<CameraConfiguration> config = */
+        /*   camera->generateConfiguration({ StreamRole::Viewfinder }); */
+        /* StreamConfiguration &streamConfig = config->at(0); */
+        /* config->validate(); */
+	/* camera->configure(config.get()); */
+    }
+    $cpp compile
+}
+
+When /someone/ wishes $::thisNode uses camera /cameraPath/ with /...options/ {
+    if {![string match "/base*" $cameraPath]} { return }
+
+    puts "camera-rpi: Running."
+
+    set width [dict get $options width]
+    set height [dict get $options height]
+    Start process "camera $cameraPath $options" {
+        Wish $::thisProcess shares statements like \
+            [list /someone/ claims camera $cameraPath /...anything/]
+
+        namespace eval Camera $makeCamera
+        Camera::cameraOpen $cameraPath $width $height
+
+        # TODO: report actual width and height from libcamera
+        Claim camera $cameraPath has width $width height $height
+
+        # puts "camera-usb: $cameraPath ($options) (tid [getTid]) booted at [clock milliseconds]"
+
+        # set ::oldFrames [list]
+        # When $::thisProcess has step count /c/ {
+        #     set frame [Camera::grayFrame $camera]
+        #     Hold {
+        #         Claim camera $cameraPath has camera time $::stepTime
+        #         Claim camera $cameraPath has frame $frame at timestamp [expr {[clock milliseconds] / 1000.0}]
+        #     }
+        #     lappend ::oldFrames $frame
+        #     if {[llength $::oldFrames] >= 10} {
+        #         set ::oldFrames [lassign $::oldFrames oldestFrame]
+        #         Camera::freeImage $oldestFrame
+        #     }
+        # }
+    }
+}
+
+# TODO: remove this; useful for compatibility with current metrics but
+# doesn't work for multicam
+set ::cameraTime none
+When camera /any/ has camera time /cameraTime/ {
+    set ::cameraTime $cameraTime
+}

--- a/virtual-programs/camera-rpi.folk
+++ b/virtual-programs/camera-rpi.folk
@@ -3,6 +3,7 @@ if {$::isLaptop} return
 set makeCamera {
     set cpp [C++]
     $cpp include <iostream>
+    $cpp include <iomanip>
     $cpp include <libcamera/libcamera.h>
     # osnr: HACK: because I'm building libcamera locally for now.
     $cpp cflags -I/usr/local/include/libcamera
@@ -11,6 +12,45 @@ set makeCamera {
     $cpp code {
         using namespace libcamera;
         std::shared_ptr<Camera> camera;
+
+        static void requestComplete(Request *request) {
+            if (request->status() == Request::RequestCancelled) {
+		return;
+            }
+
+            // TODO: copy the buffer to be managed by Folk and queue it up?
+            // is that too slow?
+            const Request::BufferMap &buffers = request->buffers();
+            for (auto bufferPair : buffers) {
+		// (Unused) Stream *stream = bufferPair.first;
+		FrameBuffer *buffer = bufferPair.second;
+		const FrameMetadata &metadata = buffer->metadata();
+
+		/* Print some information about the buffer which has completed. */
+		std::cout << " seq: " << std::setw(6) << std::setfill('0') << metadata.sequence
+			  << " timestamp: " << metadata.timestamp
+			  << " bytesused: ";
+
+		unsigned int nplane = 0;
+		for (const FrameMetadata::Plane &plane : metadata.planes())
+                    {
+			std::cout << plane.bytesused;
+			if (++nplane < metadata.planes().size())
+                            std::cout << "/";
+                    }
+
+		std::cout << std::endl;
+
+		/*
+		 * Image data can be accessed here, but the FrameBuffer
+		 * must be mapped by the application
+		 */
+            }
+
+            /* Re-queue the Request to the camera. */
+            request->reuse(Request::ReuseBuffers);
+            camera->queueRequest(request);
+        }
     }
     $cpp proc cameraOpen {char* id int width int height} void {
         std::unique_ptr<CameraManager> cm = std::make_unique<CameraManager>();
@@ -24,12 +64,83 @@ set makeCamera {
         camera = cm->get(id);
         camera->acquire();
 
-	/* std::unique_ptr<CameraConfiguration> config = */
-        /*   camera->generateConfiguration({ StreamRole::Viewfinder }); */
-        /* StreamConfiguration &streamConfig = config->at(0); */
-        /* config->validate(); */
-	/* camera->configure(config.get()); */
+	std::unique_ptr<CameraConfiguration> config =
+            camera->generateConfiguration({ StreamRole::Viewfinder });
+        StreamConfiguration &streamConfig = config->at(0);
+        config->validate();
+	camera->configure(config.get());
+
+	FrameBufferAllocator *allocator = new FrameBufferAllocator(camera);
+	for (StreamConfiguration &cfg : *config) {
+            int ret = allocator->allocate(cfg.stream());
+            if (ret < 0) {
+                FOLK_ERROR("Can't allocate buffers");
+            }
+
+            size_t allocated = allocator->buffers(cfg.stream()).size();
+            std::cout << "Allocated " << allocated << " buffers for stream" << std::endl;
+	}
+
+        Stream *stream = streamConfig.stream();
+	const std::vector<std::unique_ptr<FrameBuffer>> &buffers = allocator->buffers(stream);
+	std::vector<std::unique_ptr<Request>> requests;
+	for (unsigned int i = 0; i < buffers.size(); ++i) {
+		std::unique_ptr<Request> request = camera->createRequest();
+		if (!request)
+		{
+                    FOLK_ERROR("Can't create request");
+
+		}
+
+		const std::unique_ptr<FrameBuffer> &buffer = buffers[i];
+		int ret = request->addBuffer(stream, buffer.get());
+		if (ret < 0)
+		{
+                    FOLK_ERROR("Can't set buffer for request");
+		}
+
+		/*
+		 * Controls can be added to a request on a per frame basis.
+		 */
+		ControlList &controls = request->controls();
+		controls.set(controls::Brightness, 0.5);
+
+		requests.push_back(std::move(request));
+	}
+
+	camera->requestCompleted.connect(requestComplete);
+
+        camera->start();
+	for (std::unique_ptr<Request> &request : requests) {
+            camera->queueRequest(request.get());
+        }
     }
+
+    defineImageType $cpp
+    $cpp import ::Heap::cc folkHeapAlloc as folkHeapAlloc
+    $cpp import ::Heap::cc folkHeapFree as folkHeapFree
+
+    $cpp proc newImage {} image_t {
+        uint32_t width = 1280;
+        uint32_t height = 720;
+        int components = 1;
+        uint8_t *data = (uint8_t *)folkHeapAlloc(width*components*height);
+        return (image_t) {
+            .width = width,
+            .height = height,
+            .components = components,
+            .bytesPerRow = width*components,
+            .data = data
+        };
+    }
+    $cpp proc freeImage {image_t image} void {
+        folkHeapFree(image.data);
+    }
+
+    $cpp proc grayFrame {} image_t {
+        return newImage();
+    }
+
     $cpp compile
 }
 
@@ -50,21 +161,21 @@ When /someone/ wishes $::thisNode uses camera /cameraPath/ with /...options/ {
         # TODO: report actual width and height from libcamera
         Claim camera $cameraPath has width $width height $height
 
-        # puts "camera-usb: $cameraPath ($options) (tid [getTid]) booted at [clock milliseconds]"
+        puts "camera-rpi: $cameraPath ($options) (tid [getTid]) booted at [clock milliseconds]"
 
-        # set ::oldFrames [list]
-        # When $::thisProcess has step count /c/ {
-        #     set frame [Camera::grayFrame $camera]
-        #     Hold {
-        #         Claim camera $cameraPath has camera time $::stepTime
-        #         Claim camera $cameraPath has frame $frame at timestamp [expr {[clock milliseconds] / 1000.0}]
-        #     }
-        #     lappend ::oldFrames $frame
-        #     if {[llength $::oldFrames] >= 10} {
-        #         set ::oldFrames [lassign $::oldFrames oldestFrame]
-        #         Camera::freeImage $oldestFrame
-        #     }
-        # }
+        set ::oldFrames [list]
+        When $::thisProcess has step count /c/ {
+            set frame [Camera::grayFrame]
+            Hold {
+                Claim camera $cameraPath has camera time $::stepTime
+                Claim camera $cameraPath has frame $frame at timestamp [expr {[clock milliseconds] / 1000.0}]
+            }
+            lappend ::oldFrames $frame
+            if {[llength $::oldFrames] >= 10} {
+                set ::oldFrames [lassign $::oldFrames oldestFrame]
+                Camera::freeImage $oldestFrame
+            }
+        }
     }
 }
 

--- a/virtual-programs/camera-usb.folk
+++ b/virtual-programs/camera-usb.folk
@@ -358,7 +358,7 @@ When /someone/ wishes $::thisNode uses camera /cameraPath/ with /...options/ {
         # TODO: report actual width and height from v4l2
         Claim camera $cameraPath has width $width height $height
 
-        puts "camera.folk: $cameraPath ($options) (tid [getTid]) booted at [clock milliseconds]"
+        puts "camera-usb: $cameraPath ($options) (tid [getTid]) booted at [clock milliseconds]"
 
         set ::oldFrames [list]
         When $::thisProcess has step count /c/ {

--- a/virtual-programs/camera-usb.folk
+++ b/virtual-programs/camera-usb.folk
@@ -1,5 +1,3 @@
-if {$::isLaptop} return
-
 set makeCamera {
     rename [c create] camc
 
@@ -28,8 +26,6 @@ set makeCamera {
         uint32_t width;
         uint32_t height;
 
-        int uses_jpeg_format;
-
         size_t buffer_count;
         buffer_t* buffers;
         buffer_t head;
@@ -52,7 +48,7 @@ set makeCamera {
     }
     defineImageType camc
 
-    camc proc cameraOpen {char* device int width int height int uses_jpeg_format} camera_t* {
+    camc proc cameraOpen {char* device int width int height} camera_t* {
         printf("device [%s]\n", device);
         int fd = open(device, O_RDWR, 0);
         if (fd == -1) quit("open");
@@ -60,7 +56,6 @@ set makeCamera {
         camera->fd = fd;
         camera->width = width;
         camera->height = height;
-        camera->uses_jpeg_format = uses_jpeg_format;
         camera->buffer_count = 0;
         camera->buffers = NULL;
         camera->head.length = 0;
@@ -78,13 +73,8 @@ set makeCamera {
         format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
         format.fmt.pix.width = camera->width;
         format.fmt.pix.height = camera->height;
-        if (camera->uses_jpeg_format) {
-            // All(?) USB webcams we've encountered use this format.
-            format.fmt.pix.pixelformat = V4L2_PIX_FMT_MJPEG;
-        } else {
-            // Implementing this just for Pi camera via libcamerify.
-            format.fmt.pix.pixelformat = V4L2_PIX_FMT_YUV420;
-        }
+        // All(?) USB webcams we've encountered use this format.
+        format.fmt.pix.pixelformat = V4L2_PIX_FMT_MJPEG;
         format.fmt.pix.field = V4L2_FIELD_NONE;
         int ret;
         do {
@@ -92,13 +82,13 @@ set makeCamera {
         } while (ret == EBUSY);
         if (ret == -1) quit("VIDIOC_S_FMT");
 
-        if (!camera->uses_jpeg_format && format.fmt.pix.bytesperline != camera->width) {
-            fprintf(stderr, "cameraInit: interline padding not supported "
-                    "(bytesperline = %u, camera->width = %u)\n",
-                    format.fmt.pix.bytesperline,
-                    camera->width);
-            exit(1);
-        }
+        /* if (!camera->uses_jpeg_format && format.fmt.pix.bytesperline != camera->width) { */
+        /*     fprintf(stderr, "cameraInit: interline padding not supported " */
+        /*             "(bytesperline = %u, camera->width = %u)\n", */
+        /*             format.fmt.pix.bytesperline, */
+        /*             camera->width); */
+        /*     exit(1); */
+        /* } */
 
         struct v4l2_requestbuffers req = {0};
         req.count = 4;
@@ -108,29 +98,24 @@ set makeCamera {
         camera->buffer_count = req.count;
         camera->buffers = calloc(req.count, sizeof (buffer_t));
 
-        if (camera->uses_jpeg_format) {
-            // VIDIOC_G_PARM and VIDIOC_S_PARM are not supported by
-            // libcamerify.
+        struct v4l2_streamparm streamparm = {0};
+        streamparm.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        if (xioctl(camera->fd, VIDIOC_G_PARM, &streamparm) == -1) quit("VIDIOC_G_PARM");
+        if (streamparm.parm.capture.capability & V4L2_CAP_TIMEPERFRAME) {
+            int req_rate_numerator = 1;
+            int req_rate_denominator = 60;
+            streamparm.parm.capture.timeperframe.numerator = req_rate_numerator;
+            streamparm.parm.capture.timeperframe.denominator = req_rate_denominator;
+            if (xioctl(camera->fd, VIDIOC_S_PARM, &streamparm) == -1) { quit("VIDIOC_S_PARM"); }
 
-            struct v4l2_streamparm streamparm = {0};
-            streamparm.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-            if (xioctl(camera->fd, VIDIOC_G_PARM, &streamparm) == -1) quit("VIDIOC_G_PARM");
-            if (streamparm.parm.capture.capability & V4L2_CAP_TIMEPERFRAME) {
-                int req_rate_numerator = 1;
-                int req_rate_denominator = 60;
-                streamparm.parm.capture.timeperframe.numerator = req_rate_numerator;
-                streamparm.parm.capture.timeperframe.denominator = req_rate_denominator;
-                if (xioctl(camera->fd, VIDIOC_S_PARM, &streamparm) == -1) { quit("VIDIOC_S_PARM"); }
-
-                if (streamparm.parm.capture.timeperframe.numerator != req_rate_denominator ||
-                    streamparm.parm.capture.timeperframe.denominator != req_rate_numerator) {
-                    fprintf(stderr,
-                            "the driver changed the time per frame from "
-                            "%d/%d to %d/%d\n",
-                            req_rate_denominator, req_rate_numerator,
-                            streamparm.parm.capture.timeperframe.numerator,
-                            streamparm.parm.capture.timeperframe.denominator);
-                }
+            if (streamparm.parm.capture.timeperframe.numerator != req_rate_denominator ||
+                streamparm.parm.capture.timeperframe.denominator != req_rate_numerator) {
+                fprintf(stderr,
+                        "the driver changed the time per frame from "
+                        "%d/%d to %d/%d\n",
+                        req_rate_denominator, req_rate_numerator,
+                        streamparm.parm.capture.timeperframe.numerator,
+                        streamparm.parm.capture.timeperframe.denominator);
             }
         }
 
@@ -209,8 +194,6 @@ set makeCamera {
     }
 
     camc proc cameraDecompressRgb {camera_t* camera image_t dest} void {
-        if (!camera->uses_jpeg_format) { fprintf(stderr, "cameraDecompressRgb: non-jpeg not supported\n"); exit(1); }
-
         struct jpeg_decompress_struct cinfo;
         struct jpeg_error_mgr jerr;
         cinfo.err = jpeg_std_error(&jerr);
@@ -250,14 +233,6 @@ set makeCamera {
         }
         jpeg_finish_decompress(&cinfo);
         jpeg_destroy_decompress(&cinfo);
-    }
-    camc proc cameraDecompressGray {camera_t* camera image_t dest} void {
-        if (camera->uses_jpeg_format) {
-            cameraDecompressGrayJpeg(camera, dest);
-        } else {
-            // Planar Y:U:V 4:2:0 format. Just copy the Y plane.
-            memcpy(dest.data, camera->head.start, camera->width * camera->height);
-        }
     }
     camc proc rgbToGray {image_t rgb} image_t {
         uint8_t* gray = calloc(rgb.width * rgb.height, sizeof (uint8_t));
@@ -312,8 +287,8 @@ set makeCamera {
     }
     camc compile
 
-    proc new {device width height {usesJpegFormat 1}} {
-        set camera [cameraOpen $device $width $height $usesJpegFormat]
+    proc new {device width height} {
+        set camera [cameraOpen $device $width $height]
         cameraInit $camera
         cameraStart $camera
         # skip 5 frames for booting a cam
@@ -335,7 +310,7 @@ set makeCamera {
             error "Failed to capture from camera"
         }
         set image [newImage $camera 1]
-        cameraDecompressGray $camera $image
+        cameraDecompressGrayJpeg $camera $image
         return $image
     }
 }
@@ -348,12 +323,7 @@ When /someone/ wishes $::thisNode uses camera /cameraPath/ with /...options/ {
             [list /someone/ claims camera $cameraPath /...anything/]
 
         namespace eval Camera $makeCamera
-
-        if {[string match "gadget-*" $::thisNode]} {
-            set camera [Camera::new $cameraPath $width $height 0]
-        } else {
-            set camera [Camera::new $cameraPath $width $height 1]
-        }
+        set camera [Camera::new $cameraPath $width $height]
 
         # TODO: report actual width and height from v4l2
         Claim camera $cameraPath has width $width height $height

--- a/virtual-programs/camera-usb.folk
+++ b/virtual-programs/camera-usb.folk
@@ -316,6 +316,8 @@ set makeCamera {
 }
 
 When /someone/ wishes $::thisNode uses camera /cameraPath/ with /...options/ {
+    if {![string match "/dev*" $cameraPath]} { return }
+
     set width [dict get $options width]
     set height [dict get $options height]
     Start process "camera $cameraPath $options" {

--- a/virtual-programs/camera-usb.folk
+++ b/virtual-programs/camera-usb.folk
@@ -234,28 +234,6 @@ set makeCamera {
         jpeg_finish_decompress(&cinfo);
         jpeg_destroy_decompress(&cinfo);
     }
-    camc proc rgbToGray {image_t rgb} image_t {
-        uint8_t* gray = calloc(rgb.width * rgb.height, sizeof (uint8_t));
-        for (int y = 0; y < rgb.height; y++) {
-            for (int x = 0; x < rgb.width; x++) {
-                // we're spending 10-20% of camera time here on Pi ... ??
-
-                int i = (y * rgb.width + x) * 3;
-                uint32_t r = rgb.data[i];
-                uint32_t g = rgb.data[i + 1];
-                uint32_t b = rgb.data[i + 2];
-                // from https://mina86.com/2021/rgb-to-greyscale/
-                uint32_t yy = 3567664 * r + 11998547 * g + 1211005 * b;
-                gray[y * rgb.width + x] = ((yy + (1 << 23)) >> 24);
-            }
-        }
-        return (image_t) {
-            .width = rgb.width, .height = rgb.height,
-            .components = 1,
-            .bytesPerRow = rgb.width,
-            .data = gray
-        };
-    }
 
     if {[namespace exists ::Heap]} {
         camc import ::Heap::cc folkHeapAlloc as folkHeapAlloc


### PR DESCRIPTION
Renames camera.folk to camera-usb.folk and only uses it for USB webcams (/dev/video*). This simplifies its code and means we can get rid of the libcamerify call on gadgets (and the custom installation of libcamera needed to get that to work).

Pi camera module (distinguished by camera path) is now backed by a new camera-rpi.folk, which links to the C++ libcamera library (which is the recommended way to talk to Pi cameras). 

(this also provides precedent for stuff like @ppkn adding depth camera backend, other camera backends that can predicate on camera path)

---

[C++ support has been added to c.tcl](https://discord.com/channels/956758212152025098/1055633077323436103/1278467015757271070), which was surprisingly straightforward (just put extern C on stuff, mostly), and isn't bad to use (you have to stick to C types in the Tcl-facing interface):

![image](https://github.com/user-attachments/assets/43c93a2f-b710-4425-91a5-4ba04b5a6be6)

(hopefully this doesn't break anything on C)

(there are probably many, many useful applications of this C++ support in talking to OpenCV, MediaPipe, other C++-only libraries)

---

Subprocess deaths/crashes are now [caught by the supervisor above them](https://discord.com/channels/956758212152025098/956758650700046366/1281742264825282629) and reported on stderr, which should help clarify a lot of system failures:

![image](https://github.com/user-attachments/assets/e688ad7b-d422-4b8c-ae49-25527787e532)

(would be good to also report these deaths as a statement and maybe restart the subprocess eventually)

---

Feel free to review but will merge within 24h or so by default -- this seems reasonably safe.