### PR TITLE
Make sure to clear both mailboxes when a process is unmatched or dies

### DIFF
--- a/lib/peer.tcl
+++ b/lib/peer.tcl
@@ -36,7 +36,10 @@ proc ::peer {process {dieOnDisconnect false}} {
         }
 	proc clear {} {
             variable process
-            Mailbox::clear $process $::thisProcess
+	    variable connected
+	    set connected false
+	    Mailbox::clear $process $::thisProcess
+            Mailbox::clear $::thisProcess $process
 	}
 
         proc share {shareStatements} {

--- a/main.tcl
+++ b/main.tcl
@@ -597,6 +597,7 @@ namespace eval ::Mailbox {
     }
     $cc proc clear {char* from char* to} void {
         mailbox_t* mailbox = find(from, to);
+        fprintf(stderr, "Mailbox clear %s -> %s\n", from, to);
         pthread_mutex_lock(&mailbox->mutex); {
             mailbox->active = 0;
             mailbox->mail[0] = '\0';


### PR DESCRIPTION
I noticed a mailbox leak when I had a tag that created a new process out and due to a small visual obstruction the tag was constantly recognized and then unrecognized. After 100 recognitions the system died due to running out of mailboxes. 