### PR TITLE
Upgrade presentation of /programs

### DIFF
--- a/virtual-programs/web/programs.folk
+++ b/virtual-programs/web/programs.folk
@@ -1,0 +1,72 @@
+proc emitHTMLForProgramList {programList label} {
+    set prettyLabel [string map {- " "} $label]
+    set prettyLabel [string totitle $prettyLabel]:
+    set returnList [list "<details data-label='$label' data-count='[llength $programList]'><summary>$prettyLabel ([llength $programList])</summary>"]
+    lappend returnList "<ul>"
+    foreach item $programList {
+        lappend returnList "<li>$item</li>"
+    }
+    lappend returnList "</ul>"
+    lappend returnList "</details>"
+    join $returnList
+}
+
+Wish the web server handles route "/programs" with handler {
+    set programs [Statements::findMatches [list /someone/ claims /page/ has program /program/]]
+    set vp [list]; # virtual programs
+    set cp [list]; # core programs
+    set wp [list]; # web programs
+    set rp [list]; # real programs
+
+    foreach match $programs {
+        set page [dict get $match page]
+        switch -glob $page {
+            "virtual-programs/*" {
+                lappend vp $page
+            }
+            "setup.folk.default" {
+                lappend cp $page
+            }
+            "/home/*" {
+                lappend cp $page
+            }
+            "web-program-*" {
+                lappend wp $page
+            }
+            default {
+                lappend rp $page
+            }
+        }
+    }
+
+    html [subst {
+        <html>
+        <head>
+            <title>Running programs</title>
+            <link rel="stylesheet" href="/style.css">
+            <style>
+                body {
+                    font-family: math;
+                }
+                summary {
+                    font-family: monospace;
+                    font-size: 2em;
+                }
+            </style>
+            <script src="/lib/folk.js"></script>
+            <script>
+            /* TODO:
+                (  ) Add a ws.watch() for /someone/ claims /page/ has program /program/
+            */
+            </script>
+        </head>
+        <body>
+            [emitHTMLForProgramList $rp "real-programs"]
+            [emitHTMLForProgramList $wp "web-programs"]
+            [emitHTMLForProgramList $vp "virtual-programs"]
+            [emitHTMLForProgramList $cp "core-programs"]
+            [expr {[llength $rp] ?  "<h2>[llength $rp] [expr {[llength $rp] == 1 ? "program is" : "programs are"}] out.</h2>" : "No real programs are out."}]
+        </body>
+        </html>
+    }]
+}

--- a/virtual-programs/web/programs.folk
+++ b/virtual-programs/web/programs.folk
@@ -4,7 +4,7 @@ proc emitHTMLForProgramList {programList label} {
     set returnList [list "<details data-label='$label' data-count='[llength $programList]'><summary>$prettyLabel ([llength $programList])</summary>"]
     lappend returnList "<ul>"
     foreach item $programList {
-        lappend returnList "<li>$item</li>"
+        lappend returnList "<li><details><summary>[dict get $item programName]</summary><pre><code>[htmlEscape [lindex [dict get $item program] 1]]</code></pre></details></li>"
     }
     lappend returnList "</ul>"
     lappend returnList "</details>"
@@ -12,29 +12,29 @@ proc emitHTMLForProgramList {programList label} {
 }
 
 Wish the web server handles route "/programs" with handler {
-    set programs [Statements::findMatches [list /someone/ claims /page/ has program /program/]]
+    set programs [Statements::findMatches [list /someone/ claims /programName/ has program /program/]]
     set vp [list]; # virtual programs
     set cp [list]; # core programs
     set wp [list]; # web programs
     set rp [list]; # real programs
 
     foreach match $programs {
-        set page [dict get $match page]
-        switch -glob $page {
+        set programName [dict get $match programName]
+        switch -glob $programName {
             "virtual-programs/*" {
-                lappend vp $page
+                lappend vp $match
             }
             "setup.folk.default" {
-                lappend cp $page
+                lappend cp $match
             }
             "/home/*" {
-                lappend cp $page
+                lappend cp $match
             }
             "web-program-*" {
-                lappend wp $page
+                lappend wp $match
             }
             default {
-                lappend rp $page
+                lappend rp $match
             }
         }
     }
@@ -56,7 +56,7 @@ Wish the web server handles route "/programs" with handler {
             <script src="/lib/folk.js"></script>
             <script>
             /* TODO:
-                (  ) Add a ws.watch() for /someone/ claims /page/ has program /program/
+                (  ) Add a ws.watch() for /someone/ claims /programName/ has program /program/
             */
             </script>
         </head>

--- a/web.tcl
+++ b/web.tcl
@@ -60,23 +60,6 @@ proc handlePage {path httpStatusVar contentTypeVar} {
                 </html>
             }
         }
-        "/programs" {
-            set programs [Statements::findMatches [list /someone/ claims /programName/ has program /program/]]
-            subst {
-                <html>
-                <head>
-                <link rel="stylesheet" href="/style.css">
-                <title>Running programs</title>
-                </head>
-                <body>
-                [join [lmap p $programs { dict with p {subst {
-                    <h2>$programName</h2>
-                    <pre><code>[htmlEscape [lindex $program 1]]</code></pre>
-                }} }] "\n"]
-                </body>
-                </html>
-            }
-        }
         "/timings" {
             set runTimes [list]
             dict for {lambda runTime} $Evaluator::runTimesMap {


### PR DESCRIPTION
This is a pairing down of #171, only adding the upgrade to the `/programs` endpoint, taking it from this long, difficult to use list:

![Screenshot 2024-11-13 at 5 29 43 PM](https://github.com/user-attachments/assets/7a5b7059-5ccd-4ddf-b10a-a10592a54c6c)

to this list with nested categories, names, and code for each associated program:

![Screenshot 2024-11-13 at 5 52 29 PM](https://github.com/user-attachments/assets/b4ffba08-3e7d-4ffc-8cd8-938c8d2bb755)
![Screenshot 2024-11-13 at 5 52 56 PM](https://github.com/user-attachments/assets/30349e8f-8d6d-48ee-b8a9-6c0504e037b6)
