### PR TITLE
Add single l label with a warning

### DIFF
--- a/virtual-programs/label.folk
+++ b/virtual-programs/label.folk
@@ -4,13 +4,6 @@ When /thing/ has region /region/ {
     lassign [region centroid $region] x y
     set radians [region angle $region]
     
-    When the collected matches for [list /someone/ wishes $thing is labeled /text/ with font /font/] are /matches/ {
-        set text [join [lmap match $matches {dict get $match text}] "\n"]
-        if {$text eq ""} { return }
-        Wish $thing is labelled $text with font [dict get $match font]
-        Claim $thing has warning $singleLWarning with info $singleLWarning
-    }
-
     When the collected matches for [list /someone/ wishes $thing is labelled /text/ with font /font/] are /matches/ {
         set text [join [lmap match $matches {dict get $match text}] "\n"]
         if {$text eq ""} { return }

--- a/virtual-programs/label.folk
+++ b/virtual-programs/label.folk
@@ -1,6 +1,15 @@
+set singleLWarning "Use labelled with two l's"
+
 When /thing/ has region /region/ {
     lassign [region centroid $region] x y
     set radians [region angle $region]
+    
+    When the collected matches for [list /someone/ wishes $thing is labeled /text/ with font /font/] are /matches/ {
+        set text [join [lmap match $matches {dict get $match text}] "\n"]
+        if {$text eq ""} { return }
+        Wish $thing is labelled $text with font [dict get $match font]
+        Claim $thing has warning $singleLWarning with info $singleLWarning
+    }
 
     When the collected matches for [list /someone/ wishes $thing is labelled /text/ with font /font/] are /matches/ {
         set text [join [lmap match $matches {dict get $match text}] "\n"]
@@ -8,6 +17,11 @@ When /thing/ has region /region/ {
 
         Wish to draw text with x $x y $y text $text radians $radians font [dict get $match font]
     }
+}
+
+When /someone/ wishes /thing/ is labeled /text/ {
+  Wish $thing is labelled $text
+  Claim $thing has warning $singleLWarning with info $singleLWarning
 }
 
 When /someone/ wishes /thing/ is labelled /text/ {


### PR DESCRIPTION
Adds single-L "labeled" with a warning: `Use labelled with two l's`