### PR TITLE
Add missing projector* variables

### DIFF
--- a/virtual-programs/calibrate/calibrate.folk
+++ b/virtual-programs/calibrate/calibrate.folk
@@ -1453,6 +1453,8 @@ Stereo RMSE [dict_getdef $calibration rmse (unavailable)]
         set cameraWidth [dict get $calibration camera intrinsics width]
         set cameraHeight [dict get $calibration camera intrinsics height]
         set projectorIntrinsics [dict get $calibration projector intrinsics]
+        set projectorWidth [dict get $calibration projector intrinsics width]
+        set projectorHeight [dict get $calibration projector intrinsics height]
         dict for {id det} [dict get $pose tags] {
             # Look through all the projected tags that we detected on
             # camera in this pose.


### PR DESCRIPTION
Later used in "When the printed calibration tag size is /tagSizeMm/ mm": https://github.com/FolkComputer/folk/blob/main/virtual-programs/calibrate/calibrate.folk#L1503