### PR TITLE
Replace TAG.folkgeom with TAG.meta.folk files

### DIFF
--- a/virtual-programs/calibrate/calibrate.folk
+++ b/virtual-programs/calibrate/calibrate.folk
@@ -626,9 +626,9 @@ Claim the default program geometry is \$geom
               different size, or you manually cut and pasted the tag
               30 somewhere and want to create a specially sized region
               around that, you can set tag 30's geometry manually by making a
-              30.folkgeom text file in ~/folk-printed-programs, with content like this:</p>
+              30.meta.folk text file in ~/folk-printed-programs, with content like this:</p>
 
-              <pre>tagSize 30mm top 28mm right 28mm left 157mm bottom 80mm</pre>
+              <pre>Claim tag \$this has geometry {tagSize 30mm top 28mm right 28mm left 157mm bottom 80mm}</pre>
             </details>
           </li>
 

--- a/virtual-programs/esc-pos.folk
+++ b/virtual-programs/esc-pos.folk
@@ -48,9 +48,9 @@ namespace eval escpos {
         set matchDict [lindex $matches 0]
         if {![dict exists $matchDict geometry]} { return }
         set geometry [dict get $matchDict geometry]
-        set geomFile [open "$::env(HOME)/folk-printed-programs/$id.folkgeom" w]
-        puts $geomFile $geometry
-        close $geomFile
+        set metaFile [open "$::env(HOME)/folk-printed-programs/$id.meta.folk" w]
+        puts $metaFile [subst -novariables {Claim tag $this has geometry {[read $fd]}}]
+        close $metaFile
     }
 
     proc cut {} {

--- a/virtual-programs/programs.folk
+++ b/virtual-programs/programs.folk
@@ -19,6 +19,8 @@ When (non-capturing) /type/ /obj/ has a program {
                 puts stderr "programs: WARNING: Faulting to folk0 to try to get program $obj.folk"
                 exec curl --output "$::env(HOME)/folk-printed-programs/$obj.folk" \
                     "http://folk0.local:4273/printed-programs/$obj.folk" &
+                exec curl --output "$::env(HOME)/folk-printed-programs/$obj.meta.folk" \
+                    "http://folk0.local:4273/printed-programs/$obj.meta.folk" &
                 # HACK: It won't be reloaded until you redetect the tag.
             }
             set fd [open "$::env(HOME)/folk-printed-programs/$obj.folk" r]
@@ -27,6 +29,12 @@ When (non-capturing) /type/ /obj/ has a program {
         close $fd
 
         Claim $obj has program code $code
+
+        if {[file exists "$::env(HOME)/folk-printed-programs/$obj.meta.folk"]} {
+            set mfd [open "$::env(HOME)/folk-printed-programs/$obj.meta.folk" r]
+            set metacode [read $mfd]; close $mfd
+            apply [list {this} $metacode] $obj
+        }
     } on error error {
         puts stderr "No code for $type $obj"
     }

--- a/virtual-programs/tags-to-quads.folk
+++ b/virtual-programs/tags-to-quads.folk
@@ -513,24 +513,31 @@ namespace eval ::quad {
 Claim the tags-to-quads C library is $cc
 $cc compile
 
-When when tag /tag/ has geometry /geomVar/ /any/ with environment /any/ {
+# This (resolved geometry) feels like a hack.
+
+When when tag /tag/ has resolved geometry /geomVar/ /any/ with environment /any/ {
     # Setting aside this tag space (48600 to 48713) for calibration.
     if {$tag >= 48600} { return }
 
-    Wish tag $tag has geometry
+    Wish tag $tag has resolved geometry
 }
 When the default program geometry is /defaultGeom/ &\
-     /someone/ wishes tag /tag/ has geometry {
+     /someone/ wishes tag /tag/ has resolved geometry {
 
     # Setting aside this tag space (48600 to 48713) for calibration.
     if {$tag >= 48600} { return }
 
-    if {[file exists "$::env(HOME)/folk-printed-programs/$tag.folkgeom"]} {
-        set fd [open "$::env(HOME)/folk-printed-programs/$tag.folkgeom" r]
-        set geom [read $fd]; close $fd
-        Claim tag $tag has geometry $geom
-    } else {
-        Claim tag $tag has geometry $defaultGeom
+    When the collected matches for [list /someone/ claims tag $tag has geometry /geom/] are /matches/ {
+        if {[llength $matches] == 1} {
+            Claim tag $tag has resolved geometry [dict get [lindex $matches 0] geom]
+
+        } elseif {[llength $matches] == 0} {
+            Claim tag $tag has resolved geometry $defaultGeom
+
+        } else {
+            puts stderr "tags-to-quads: WARNING: Multiple geometries for $tag"
+            Claim tag $tag has resolved geometry [dict get [lindex $matches 0] geom]
+        }
     }
 }
 
@@ -539,7 +546,7 @@ When camera /camera/ has width /cameraWidth/ height /cameraHeight/ &\
 
     set ::prevTagPoses [dict create]
     When tag /tag/ has detection /det/ on $camera at /timestamp/ &\
-         tag /tag/ has geometry /geom/ {
+         tag /tag/ has resolved geometry /geom/ {
 
         set tagSize [expr {[string map {mm ""} [dict get $geom tagSize]] / 1000.0}]
 
@@ -585,7 +592,7 @@ When camera /camera/ has width /cameraWidth/ height /cameraHeight/ &\
 }
 
 When tag /tag/ has quad /q/ &\
-     tag /tag/ has geometry /geom/ {
+     tag /tag/ has resolved geometry /geom/ {
 
     set pageQuad [quad buffer $q \
                       top [dict_getdef $geom top 0] \

--- a/virtual-programs/web/web-printed-programs.folk
+++ b/virtual-programs/web/web-printed-programs.folk
@@ -1,6 +1,6 @@
-Wish the web server handles route {/printed-programs/(\d+)\.folk$} with handler {
-    regexp {/printed-programs/(\d+)\.folk$} $path -> id
-    set filename "../folk-printed-programs/$id.folk" 
+Wish the web server handles route {/printed-programs/[^/]+\.folk$} with handler {
+    regexp {/printed-programs/([^/]+)\.folk$} $path -> prefix
+    set filename "../folk-printed-programs/$prefix.folk" 
     set fp [open $filename r]
     set data [read $fp]
     close $fp


### PR DESCRIPTION
This is so that we can move toward more annotated physical regions (writable fields, etc) which we could specify in the .meta file, since its format is much more general. See https://discord.com/channels/956758212152025098/956758650700046366/1280485062156222465

Touches esc-pos code but haven't tested that.

You can migrate all your existing .folkgeom files with this Tcl script:
```
foreach filename [glob -nocomplain "$::env(HOME)/folk-printed-programs/*.folkgeom"] {
    if {![regexp {.*/([A-Za-z0-9]+)\.folkgeom} $filename -> id]} {
        puts stderr "Failure to match $filename"
    }
    if {$id eq "default"} {
        puts "$filename: Skipping"
        return
    }
    puts "$filename:"
    set fd [open $filename r]
    set metacode [subst -novariables {Claim tag $this has geometry {[read $fd]}}]
    close $fd
    puts $metacode

    set fd [open "$::env(HOME)/folk-printed-programs/$id.meta.folk" w]
    puts $fd $metacode
    close $fd

    puts ""
}
```