### PR TITLE
base64-encode web-edited program code to preserve backslash-newline

### DIFF
--- a/virtual-programs/web/new-program-web-editor.folk
+++ b/virtual-programs/web/new-program-web-editor.folk
@@ -134,14 +134,17 @@ Wish the web server handles route "/new" with handler {
   }
   function handleSave() {
     const code = document.getElementById("code").value;
+    // base64-encoding the code ensures that backslash-newlines are
+    // preserved in the code and printout (otherwise, braced-string-parsing
+    // would elide them: https://www.tcl.tk/man/tcl8.7/TclCmd/Tcl.html#M10)
     ws.hold('code', tcl`
-      Claim ${program} has program code ${code}
+      Claim ${program} has program code [binary decode base64 ${btoa(code)}]
     `);
   }
   function handlePrint() {
     const code = document.getElementById("code").value;
     const jobid = String(Math.random());
-    ws.send(tcl`Wish to print ${code} with job-id ${jobid}`);
+    ws.send(tcl`Wish to print [binary decode base64 ${btoa(code)}] with job-id ${jobid}`);
     let printBtn = document.getElementById("printBtn")
     printBtn.innerText = "Printing";
     printBtn.disabled = true;

--- a/virtual-programs/web/web-editor.folk
+++ b/virtual-programs/web/web-editor.folk
@@ -72,13 +72,13 @@ Wish the web server handles route {/page/(.*)$} with handler {
             const code = document.getElementById("code").value;
             ws.send(tcl`
               set fp [open file_name w]
-              puts -nonewline $fp ${code}
+              puts -nonewline $fp [binary decode base64 ${btoa(code)}]
               close $fp
               puts "Saved program_id.folk"
             `);
 
             if (isVirtualProgram) {
-              ws.send(tcl`EditVirtualProgram file_name ${code}`)
+              ws.send(tcl`EditVirtualProgram file_name [binary decode base64 ${btoa(code)}`)
             }
           }
 
@@ -86,7 +86,7 @@ Wish the web server handles route {/page/(.*)$} with handler {
           function handlePrint() {
             const code = document.getElementById("code").value;
             jobid = String(Math.random());
-            ws.send(tcl`Wish to print program program_id with code ${code} job-id ${jobid}`);
+            ws.send(tcl`Wish to print program program_id with code [binary decode base64 ${btoa(code)}] job-id ${jobid}`);
           }
         </script>
         </body>


### PR DESCRIPTION
Previously, backslash-and-then-newline in program code in web editor would get elided down to a space, because of
https://www.tcl.tk/man/tcl8.7/TclCmd/Tcl.html#M10 (this is the only case, other than before a brace, where backslashes still have escaping behavior in Tcl even in curly-braced strings.)

This should make it easier to do intentional ASCII space layout and to intentionally break your code over multiple lines. Like this:

```
# You physically write in the blanks on the
# printed program. (Blank2 means the captured
# regions are 2-line height instead of 1-line
# height, to include the blank line above.)

# When the program executes (is seen by the
# camera), all blanks are camera-captured and
# (maybe) OCRed. (We'd have to yield to the
# evaluator to do that, or do a synchronous
# Query!)

# Then board here is a Tcl value that is a list of lists of either
# images or strings (OCRed). Not sure.
set board [list \
  \
  [list [Blank2 _____] [Blank2 _____] [Blank2 _____]] \
  \
  [list [Blank2 _____] [Blank2 _____] [Blank2 _____]] \
  \
  [list [Blank2 _____] [Blank2 _____] [Blank2 _____]] \
]
```

(see all the trailing backslashes?) should come out like this:

![image](https://github.com/user-attachments/assets/4181feed-e04e-4905-be30-1d9a857d1bf2)


Tests:
- on /new: save new program, print new program
- on /page/WHATEVER: save existing program, reprint existing program