### PR TITLE
Fix calibration link

### DIFF
--- a/web.tcl
+++ b/web.tcl
@@ -49,7 +49,7 @@ proc handlePage {path httpStatusVar contentTypeVar} {
                 </head>
                 <nav>
                 <a href="/new"><button>New program</button></a>
-                <a href="/calibration">Calibration</a>
+                <a href="/calibrate">Calibration</a>
                 <a href="/programs">Running programs</a>
                 <a href="/timings">Timings</a>
                 <a href="/keyboards">Keyboards</a>


### PR DESCRIPTION
I used `/calibration` (wrong) instead of `/calibrate` (right) in the last PR.