### PR TITLE
Allow buffer lengths to be set in config

### DIFF
--- a/setup.folk.default
+++ b/setup.folk.default
@@ -1,6 +1,6 @@
 # Copy this file to ~/folk-live/setup.folk and edit it to make
 # changes.
 
-Assert $this wishes $::thisNode uses camera "/dev/video0" with width 1280 height 720
+Assert $this wishes $::thisNode uses camera "/dev/video0" with width 1280 height 720 bufferCount 4
 
-Assert $this wishes $::thisNode uses display 0
+Assert $this wishes $::thisNode uses display 0 with swapchainPadding 1

--- a/virtual-programs/camera-usb.folk
+++ b/virtual-programs/camera-usb.folk
@@ -301,7 +301,7 @@ When /someone/ wishes $::thisNode uses camera /cameraPath/ with /...options/ {
 
     set width [dict get $options width]
     set height [dict get $options height]
-    set bufferCount [dict get $options bufferCount]
+    set bufferCount [dict_getdef $options bufferCount 4]
 
     if {[dict exists $options crop]} {
         set crop [dict get $options crop]

--- a/virtual-programs/camera-usb.folk
+++ b/virtual-programs/camera-usb.folk
@@ -63,7 +63,7 @@ set makeCamera {
         return camera;
     }
 
-    camc proc cameraInit {camera_t* camera} void {
+    camc proc cameraInit {camera_t* camera uint32_t requested_buffer_count } void {
         struct v4l2_capability cap;
         if (xioctl(camera->fd, VIDIOC_QUERYCAP, &cap) == -1) quit("VIDIOC_QUERYCAP");
         if (!(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE)) quit("no capture");
@@ -91,12 +91,15 @@ set makeCamera {
         /* } */
 
         struct v4l2_requestbuffers req = {0};
-        req.count = 4;
+        req.count = requested_buffer_count;
         req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
         req.memory = V4L2_MEMORY_MMAP;
         if (xioctl(camera->fd, VIDIOC_REQBUFS, &req) == -1) quit("VIDIOC_REQBUFS");
         camera->buffer_count = req.count;
         camera->buffers = calloc(req.count, sizeof (buffer_t));
+
+        printf("LATENCY: Camera buffer count: %d\n", req.count);
+        fflush(stdout);
 
         struct v4l2_streamparm streamparm = {0};
         streamparm.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
@@ -265,9 +268,9 @@ set makeCamera {
     }
     camc compile
 
-    proc new {device width height} {
+    proc new {device width height bufferCount } {
         set camera [cameraOpen $device $width $height]
-        cameraInit $camera
+        cameraInit $camera $bufferCount
         cameraStart $camera
         # skip 5 frames for booting a cam
         for {set i 0} {$i < 5} {incr i} {
@@ -298,6 +301,8 @@ When /someone/ wishes $::thisNode uses camera /cameraPath/ with /...options/ {
 
     set width [dict get $options width]
     set height [dict get $options height]
+    set bufferCount [dict get $options bufferCount]
+
     if {[dict exists $options crop]} {
         set crop [dict get $options crop]
     }
@@ -321,7 +326,7 @@ When /someone/ wishes $::thisNode uses camera /cameraPath/ with /...options/ {
             [list /someone/ claims camera $cameraPath /...anything/]
 
         namespace eval Camera $makeCamera
-        set camera [Camera::new $cameraPath $width $height]
+        set camera [Camera::new $cameraPath $width $height $bufferCount]
 
         # TODO: report actual width and height from v4l2
         Claim camera $cameraPath has width $width height $height

--- a/virtual-programs/display.folk
+++ b/virtual-programs/display.folk
@@ -105,7 +105,7 @@ Try doing `sudo adduser folk render`."
         VkSemaphore renderFinishedSemaphore;
         VkFence inFlightFence;
     }
-    dc proc init {int displayIdx} void [csubst {
+    dc proc init {int displayIdx uint32_t swapchainPadding} void [csubst {
         $[vktry volkInitialize()]
         $[if {$macos} { expr {"glfwInit();"} }]
 
@@ -298,7 +298,7 @@ Try doing `sudo adduser folk render`."
                 } : {} }]
             }
 
-            imageCount = capabilities.minImageCount + 1;
+            imageCount = capabilities.minImageCount + swapchainPadding;
             if (capabilities.maxImageCount > 0 && imageCount > capabilities.maxImageCount) {
                 imageCount = capabilities.maxImageCount;
             }
@@ -359,6 +359,10 @@ Try doing `sudo adduser folk render`."
 
         // Set up uint32_t swapchainImageCount:
         vkGetSwapchainImagesKHR(device, swapchain, &swapchainImageCount, NULL);
+
+        printf("LATENCY: Display swapchain image count: %d\n", swapchainImageCount);
+        fflush(stdout);
+
         VkImage swapchainImages[swapchainImageCount];
         VkFormat swapchainImageFormat;
         // Set up VkExtent2D swapchainExtent:
@@ -1626,7 +1630,7 @@ Start-display-process {
     source "lib/colors.tcl"
 
     Wish $::thisProcess receives statements like \
-        [list /someone/ wishes $::thisNode uses display /displayIdx/]
+        [list /someone/ wishes $::thisNode uses display /displayIdx/ /...anything/]
     Wish $::thisProcess receives statements like \
         [list /someone/ wishes the GPU /...anything/]
     Wish $::thisProcess shares statements like \
@@ -1636,8 +1640,10 @@ Start-display-process {
     Wish $::thisProcess shares statements like \
         [list /someone/ has error /err/ with info /errorInfo/]
 
-    When /someone/ wishes $::thisNode uses display /displayIdx/ {
-        Gpu::init $displayIdx
+    When /someone/ wishes $::thisNode uses display /displayIdx/ with /...options/ {
+        set swapchainPadding [dict get $options swapchainPadding]
+
+        Gpu::init $displayIdx $swapchainPadding
         Gpu::ImageManager::imageManagerInit
 
         Claim display $displayIdx has width [Gpu::getWidth] height [Gpu::getHeight]

--- a/virtual-programs/display.folk
+++ b/virtual-programs/display.folk
@@ -1630,7 +1630,7 @@ Start-display-process {
     source "lib/colors.tcl"
 
     Wish $::thisProcess receives statements like \
-        [list /someone/ wishes $::thisNode uses display /displayIdx/ /...anything/]
+        [list /someone/ wishes $::thisNode uses display /...anything/]
     Wish $::thisProcess receives statements like \
         [list /someone/ wishes the GPU /...anything/]
     Wish $::thisProcess shares statements like \
@@ -1639,6 +1639,11 @@ Start-display-process {
         [list /someone/ claims display /any/ has width /w/ height /h/]
     Wish $::thisProcess shares statements like \
         [list /someone/ has error /err/ with info /errorInfo/]
+
+    # for backwards compatibility
+    When /someone/ wishes $::thisNode uses display /displayIdx/ {
+        Wish $::thisNode uses display $displayIdx with swapchainPadding 1
+    }
 
     When /someone/ wishes $::thisNode uses display /displayIdx/ with /...options/ {
         set swapchainPadding [dict get $options swapchainPadding]


### PR DESCRIPTION
The camera and display buffer length is currently hard-coded. I was able to reduce latency on my setup by reducing the swapchain and camera buffer lengths, so it makes sense for this to be configurable.