### PR TITLE
Shapes refactor

### DIFF
--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -1,8 +1,5 @@
-# Dictionary mapping shape names to number of sides
-set shapes [dict create triangle 3 square 4 pentagon 5 hexagon 6 \
-                septagon 7 octagon 8 nonagon 9]
+set shapes [dict create triangle 3 square 4 pentagon 5 hexagon 6 septagon 7 octagon 8 nonagon 9]
 
-# Core shape drawing function - creates regular polygons
 When /someone/ wishes to draw a shape with /...options/ {
   set numPoints [dict get $options sides]
   set c [dict get $options center]
@@ -13,25 +10,20 @@ When /someone/ wishes to draw a shape with /...options/ {
   set layer [dict_getdef $options layer 0]
   set width [dict_getdef $options width 1]
 
-  set p [list 0 0]
-  set centerPoint $p
-  set points [list $p]
-
-  set incr [expr {2 * 3.14159 / $numPoints}]
-  set a [expr {$incr + 3.14159}]
+  set points {{0 0}}
+  set centerPoint {0 0}
+  set angle [expr {2 * 3.14159 / $numPoints + 3.14159}]
+  set angleIncr [expr {2 * 3.14159 / $numPoints}]
+  
   for {set i 0} {$i < $numPoints} {incr i} {
-    set p [vec2 add $p [vec2 scale [list [expr {cos($a)}] [expr {sin($a)}]] $r]]
+    set p [vec2 add [lindex $points end] [vec2 scale [list [expr {cos($angle)}] [expr {sin($angle)}]] $r]]
     lappend points $p
     set centerPoint [vec2 add $centerPoint $p]
-    set a [expr {$a + $incr}]
+    set angle [expr {$angle + $angleIncr}]
   }
-  set centerPoint [vec2 scale $centerPoint [expr {1.0/$numPoints}]]
-
+  
   set points [lmap v $points {
-      set v [vec2 sub $v $centerPoint]
-      set v [vec2 rotate $v $radians]
-      set v [vec2 add $v $c]
-      set v
+      vec2 add [vec2 rotate [vec2 sub $v [vec2 scale $centerPoint [expr {1.0/$numPoints}]]] $radians] $c
   }]
 
   if {$filled} {
@@ -41,38 +33,33 @@ When /someone/ wishes to draw a shape with /...options/ {
   }
 }
 
-# Rectangle drawing function with rotation around regional center
 When /someone/ wishes to draw a rect with /...options/ {
   set c [dict get $options center]
-  set width [dict_getdef $options width 100]
-  set height [dict_getdef $options height 100]
+  set w [dict_getdef $options width 100]
+  set h [dict_getdef $options height 100]
   set radians [dict_getdef $options radians 0]
   set color [dict_getdef $options color white]
   set filled [dict_getdef $options filled false]
-  set strokeWidth [dict_getdef $options strokeWidth 1]
+  set width [dict_getdef $options strokeWidth 1]
   set layer [dict_getdef $options layer 0]
   
-  set halfWidth [expr {$width / 2.0}]
-  set halfHeight [expr {$height / 2.0}]
+  set hw [expr {$w / 2.0}]
+  set hh [expr {$h / 2.0}]
   
-  set points [list \
-      [list [expr {-$halfWidth}] [expr {-$halfHeight}]] \
-      [list [expr {$halfWidth}] [expr {-$halfHeight}]] \
-      [list [expr {$halfWidth}] [expr {$halfHeight}]] \
-      [list [expr {-$halfWidth}] [expr {$halfHeight}]] \
-      [list [expr {-$halfWidth}] [expr {-$halfHeight}]] \
-  ]
-  
-  set points [lmap v $points {
-      set v [vec2 rotate $v $radians]
-      set v [vec2 add $v $c]
-      set v
+  set points [lmap v [list \
+      [list [expr {-$hw}] [expr {-$hh}]] \
+      [list [expr {$hw}] [expr {-$hh}]] \
+      [list [expr {$hw}] [expr {$hh}]] \
+      [list [expr {-$hw}] [expr {$hh}]] \
+      [list [expr {-$hw}] [expr {-$hh}]] \
+  ] {
+      vec2 add [vec2 rotate $v $radians] $c
   }]
   
   if {$filled} {
       Wish to draw a polygon with points $points color $color layer $layer
   } else {
-      Wish to draw a stroke with points $points width $strokeWidth color $color layer $layer
+      Wish to draw a stroke with points $points width $width color $color layer $layer
   }
 }
 
@@ -85,134 +72,131 @@ When /someone/ wishes /p/ draws an /shape/ {
 }
 
 When /someone/ wishes /p/ draws a /shape/ with /...options/ & /p/ has region /r/ {
-  # Get the region's properties
   lassign [region centroid $r] cx cy
   set angle [region angle $r]
-  set width [region width $r]
-  set height [region height $r]
   
-  # Extract parameters
   set radius [dict_getdef $options radius 50]
   set color [dict_getdef $options color white]
   set filled [dict_getdef $options filled false]
   set thickness [dict_getdef $options thickness 5]
   set layer [dict_getdef $options layer 0]
   
-  # Rotate offset vector by region's angle for consistent positioning
-  lassign [dict_getdef $options offset {0 0}] offsetX offsetY
-  set rotatedOffset [vec2 rotate [list $offsetX $offsetY] $angle]
-  
-  # Calculate final center position
-  set finalCenter [vec2 add [list $cx $cy] $rotatedOffset]
+  lassign [dict_getdef $options offset {0 0}] ox oy
+  set center [vec2 add [list $cx $cy] [vec2 rotate [list $ox $oy] $angle]]
 
-  # Draw appropriate shape
   if {$shape eq "circle"} {
-      Wish to draw a circle with \
-          center $finalCenter radius $radius thickness $thickness \
+      Wish to draw a circle with center $center radius $radius thickness $thickness \
           color $color filled $filled layer $layer
   } elseif {$shape eq "rect"} {
-      set rectWidth [dict_getdef $options width $width]
-      set rectHeight [dict_getdef $options height $height]
-      Wish to draw a rect with \
-          center $finalCenter width $rectWidth height $rectHeight radians $angle \
-          color $color filled $filled strokeWidth $thickness layer $layer
+      set w [dict_getdef $options width [region width $r]]
+      set h [dict_getdef $options height [region height $r]]
+      Wish to draw a rect with center $center width $w height $h radians $angle \
+          color $color filled $filled thickness $thickness layer $layer
   } elseif {[dict exists $shapes $shape]} {
-      Wish to draw a shape with sides [dict get $shapes $shape] \
-          center $finalCenter radius $radius radians $angle \
-          color $color filled $filled width $thickness layer $layer
+      Wish to draw a shape with sides [dict get $shapes $shape] center $center radius $radius \
+          radians $angle color $color filled $filled width $thickness layer $layer
   } else {
-      # Default to a line (2 sides) if shape not recognized
-      Wish to draw a shape with sides 2 \
-          center $finalCenter radius $radius radians $angle \
-          color $color filled $filled width $thickness layer $layer
+      Wish to draw a shape with sides 2 center $center radius $radius \
+          radians $angle color $color filled $filled width $thickness layer $layer
   }
 }
 
-# Handle "an" grammar variant with options
 When /someone/ wishes /p/ draws an /shape/ with /...options/ {
   Wish $p draws a $shape with {*}$options
 }
 
-# Specialized rectangle drawing with consistent positioning and rotation
-When /someone/ wishes /p/ draw a rect with width /w/ height /h/ shifted /direction/ /pct/ {
-  When $p has region /r/ {
-    # Get the region's properties
-    lassign [region centroid $r] cx cy
-    set angle [region angle $r]
+proc shift_region {region direction pct} {
+    set pct [expr {[string map {% ""} $pct] / 100.0}]
+    set w [region width $region]
+    set h [region height $region]
     
-    # Strip percentage sign if present and convert to decimal
-    set pctValue [string map {% ""} $pct]
-    set pctFraction [expr {$pctValue / 100.0}]
-    
-    # Determine the direction vector based on region width/height
-    set width [region width $r]
-    set offset 0
-    
-    if {$direction eq "right"} {
-      set offset [expr {$width * $pctFraction}]
-      set offsetVec [list $offset 0]
-    } elseif {$direction eq "left"} {
-      set offset [expr {-$width * $pctFraction}]
-      set offsetVec [list $offset 0]
-    } elseif {$direction eq "up"} {
-      set height [region height $r]
-      set offset [expr {-$height * $pctFraction}]
-      set offsetVec [list 0 $offset]
-    } elseif {$direction eq "down"} {
-      set height [region height $r]
-      set offset [expr {$height * $pctFraction}]
-      set offsetVec [list 0 $offset]
-    } else {
-      # Default to right if invalid direction
-      set offset [expr {$width * $pctFraction}]
-      set offsetVec [list $offset 0]
+    switch $direction {
+        "right" { region move $region right [expr {$w * $pct}]px }
+        "left"  { region move $region left [expr {$w * $pct}]px }
+        "up"    { region move $region up [expr {$h * $pct}]px }
+        "down"  { region move $region down [expr {$h * $pct}]px }
+        default { region move $region right [expr {$w * $pct}]px }
     }
-    
-    # Rotate the offset vector based on region's angle
-    set rotatedOffset [vec2 rotate $offsetVec $angle]
-    
-    # Calculate final center position
-    set finalCenter [vec2 add [list $cx $cy] $rotatedOffset]
-    
-    # Draw the rectangle with same rotation as region
-    Wish to draw a rect with center $finalCenter width $w height $h radians $angle color white
+}
+
+When /someone/ wishes /p/ draw a rect with width /w/ height /h/ shift /direction/ /pct/ {
+  When $p has region /r/ {
+    set shifted [shift_region $r $direction $pct]
+    lassign [region centroid $shifted] cx cy
+    Wish to draw a rect with center [list $cx $cy] width $w height $h radians [region angle $r] color white
   }
 }
 
-# Simplified syntax for drawing rectangles relative to a region
-When /someone/ wishes /p/ draws a rect with width /w/ height /h/ {
+When /someone/ wishes /p/ draw a /shape/ with radius /rad/ shift /direction/ /pct/ {
   When $p has region /r/ {
-    lassign [region centroid $r] cx cy
-    set angle [region angle $r]
-    Wish to draw a rect with center [list $cx $cy] width $w height $h radians $angle color white
+    set shifted [shift_region $r $direction $pct]
+    lassign [region centroid $shifted] cx cy
+    
+    if {[dict exists $shapes $shape]} {
+        Wish to draw a shape with sides [dict get $shapes $shape] center [list $cx $cy] radius $rad color white
+    } else {
+        Wish $p draws a $shape with center [list $cx $cy] radius $rad color white
+    }
+  }
+}
+
+When /someone/ wishes /p/ draw a rect with width /w/ height /h/ {
+  Wish to draw a rect with center {0 0} width $w height $h radians 0 color white
+}
+
+When /someone/ wishes /p/ draw a /shape/ with radius /rad/ {
+  if {[dict exists $shapes $shape]} {
+    Wish to draw a shape with sides [dict get $shapes $shape] center {0 0} radius $rad color white
+  } else {
+    Wish to draw a $shape with center {0 0} radius $rad color white
   }
 }
 
 Claim $this has demo {
+  # Center circle
   Wish $this draws a circle
-  Wish $this draws a triangle with color skyblue
-  Wish $this draws a triangle with color green offset {-280 0}
-  Wish $this draws a pentagon with color gold offset {-200 0}
-  Wish $this draws an octagon with color red offset {-250 80}
   
-  # Rectangle examples
-  Wish $this draws a rect with width 150 height 75 color cyan filled true offset {-250 -250}
-  Wish $this draw a rect with width 85 height 110 shifted right 150%
-  Wish $this draw a rect with width 85 height 110 shifted left 100%
+  # Grid of shapes with varying thickness
+  set baseX -850
+  set baseY -200
+  set gridSpacing 130
   
-  # Animated circle
+  # Row 1: Regular polygons with different colors and thickness
+  Wish $this draws a triangle with color skyblue width 2 offset [list $baseX [expr {$baseY}]]
+  Wish $this draws a square with color green width 4 offset [list [expr {$baseX + $gridSpacing}] [expr {$baseY}]]
+  Wish $this draws a pentagon with color gold width 6 offset [list [expr {$baseX + $gridSpacing*2}] [expr {$baseY}]]
+  Wish $this draws a hexagon with color orange width 8 offset [list [expr {$baseX + $gridSpacing*3}] [expr {$baseY}]]
+  
+  # Row 2: Filled shapes
+  Wish $this draws a triangle with color skyblue filled true offset [list $baseX [expr {$baseY + $gridSpacing}]]
+  Wish $this draws a square with color green filled true offset [list [expr {$baseX + $gridSpacing}] [expr {$baseY + $gridSpacing}]]
+  Wish $this draws a pentagon with color gold filled true offset [list [expr {$baseX + $gridSpacing*2}] [expr {$baseY + $gridSpacing}]]
+  Wish $this draws a hexagon with color orange filled true offset [list [expr {$baseX + $gridSpacing*3}] [expr {$baseY + $gridSpacing}]]
+  
+  # Row 3: Shifting examples
+  Wish $this draw a triangle with radius 40 shift right 50%
+  Wish $this draw a square with radius 40 shift left 50%
+  Wish $this draw a pentagon with radius 40 shift up 50%
+  Wish $this draw a hexagon with radius 40 shift down 50%
+  
+  # Row 4: Rectangles with different properties
+  Wish $this draws a rect with width 80 height 50 color cyan thickness 3 offset [list $baseX [expr {$baseY + $gridSpacing*3}]]
+  Wish $this draws a rect with width 80 height 50 color magenta filled true offset [list [expr {$baseX + $gridSpacing}] [expr {$baseY + $gridSpacing*3}]]
+  Wish $this draw a rect with width 80 height 50 shift right 50%
+  Wish $this draw a rect with width 80 height 50 shift left 50%
+  
+  # Animated elements
   When the clock time is /t/ {
     set offsetVector [list [sin $t] [cos $t]]
     set offsetVector [::vec2::scale $offsetVector 105]
     Wish $this draws a circle with color palegoldenrod offset $offsetVector
   }
 
-  # This toggles a square between filled and unfilled
   When $this has region /r/ & the clock time is /t/ {
     lassign [region centroid $r] x y
     set fill [expr {round(sin($t) * 2) % 2 == 0}]
     set y [- $y 150]
-    Wish to draw a shape with sides 4 center [list [- $x 100] $y] radius 60 color white filled $fill
+    Wish to draw a square with center [list [- $x 100] $y] radius 60 color white filled $fill
   }
 
   Wish $this is outlined white

--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -14,24 +14,24 @@ When /someone/ wishes to draw a shape with /...options/ {
   set centerPoint {0 0}
   set angle [expr {2 * 3.14159 / $numPoints + 3.14159}]
   set angleIncr [expr {2 * 3.14159 / $numPoints}]
-  
+
   for {set i 0} {$i < $numPoints} {incr i} {
     set p [vec2 add [lindex $points end] [vec2 scale [list [expr {cos($angle)}] [expr {sin($angle)}]] $r]]
     lappend points $p
     set centerPoint [vec2 add $centerPoint $p]
     set angle [expr {$angle + $angleIncr}]
   }
-  
-  set points [lmap v $points {
-      vec2 add [vec2 rotate [vec2 sub $v [vec2 scale $centerPoint [expr {1.0/$numPoints}]]] $radians] $c
-  }]
 
-  if {$filled} {
-    Wish to draw a polygon with points $points color $color layer $layer
-  } else {
-    Wish to draw a stroke with points $points width $width color $color layer $layer
+  set points [lmap v $points {
+    vec2 add [vec2 rotate [vec2 sub $v [vec2 scale $centerPoint [expr {1.0/$numPoints}]]] $radians] $c
+    }]
+
+    if {$filled} {
+      Wish to draw a polygon with points $points color $color layer $layer
+    } else {
+      Wish to draw a stroke with points $points width $width color $color layer $layer
+    }
   }
-}
 
 When /someone/ wishes to draw a rect with /...options/ {
   set c [dict get $options center]
@@ -42,24 +42,24 @@ When /someone/ wishes to draw a rect with /...options/ {
   set filled [dict_getdef $options filled false]
   set width [dict_getdef $options strokeWidth 1]
   set layer [dict_getdef $options layer 0]
-  
+
   set hw [expr {$w / 2.0}]
   set hh [expr {$h / 2.0}]
-  
+
   set points [lmap v [list \
-      [list [expr {-$hw}] [expr {-$hh}]] \
-      [list [expr {$hw}] [expr {-$hh}]] \
-      [list [expr {$hw}] [expr {$hh}]] \
-      [list [expr {-$hw}] [expr {$hh}]] \
-      [list [expr {-$hw}] [expr {-$hh}]] \
-  ] {
+    [list [expr {-$hw}] [expr {-$hh}]] \
+    [list [expr {$hw}] [expr {-$hh}]] \
+    [list [expr {$hw}] [expr {$hh}]] \
+    [list [expr {-$hw}] [expr {$hh}]] \
+    [list [expr {-$hw}] [expr {-$hh}]] \
+    ] {
       vec2 add [vec2 rotate $v $radians] $c
-  }]
-  
+    }]
+
   if {$filled} {
-      Wish to draw a polygon with points $points color $color layer $layer
+    Wish to draw a polygon with points $points color $color layer $layer
   } else {
-      Wish to draw a stroke with points $points width $width color $color layer $layer
+    Wish to draw a stroke with points $points width $width color $color layer $layer
   }
 }
 
@@ -74,30 +74,30 @@ When /someone/ wishes /p/ draws an /shape/ {
 When /someone/ wishes /p/ draws a /shape/ with /...options/ & /p/ has region /r/ {
   lassign [region centroid $r] cx cy
   set angle [region angle $r]
-  
+
   set radius [dict_getdef $options radius 50]
   set color [dict_getdef $options color white]
   set filled [dict_getdef $options filled false]
   set thickness [dict_getdef $options thickness 5]
   set layer [dict_getdef $options layer 0]
-  
+
   lassign [dict_getdef $options offset {0 0}] ox oy
   set center [vec2 add [list $cx $cy] [vec2 rotate [list $ox $oy] $angle]]
 
   if {$shape eq "circle"} {
-      Wish to draw a circle with center $center radius $radius thickness $thickness \
-          color $color filled $filled layer $layer
+    Wish to draw a circle with center $center radius $radius thickness $thickness \
+      color $color filled $filled layer $layer
   } elseif {$shape eq "rect"} {
-      set w [dict_getdef $options width [region width $r]]
-      set h [dict_getdef $options height [region height $r]]
-      Wish to draw a rect with center $center width $w height $h radians $angle \
-          color $color filled $filled thickness $thickness layer $layer
+    set w [dict_getdef $options width [region width $r]]
+    set h [dict_getdef $options height [region height $r]]
+    Wish to draw a rect with center $center width $w height $h radians $angle \
+      color $color filled $filled thickness $thickness layer $layer
   } elseif {[dict exists $shapes $shape]} {
-      Wish to draw a shape with sides [dict get $shapes $shape] center $center radius $radius \
-          radians $angle color $color filled $filled width $thickness layer $layer
+    Wish to draw a shape with sides [dict get $shapes $shape] center $center radius $radius \
+      radians $angle color $color filled $filled width $thickness layer $layer
   } else {
-      Wish to draw a shape with sides 2 center $center radius $radius \
-          radians $angle color $color filled $filled width $thickness layer $layer
+    Wish to draw a shape with sides 2 center $center radius $radius \
+      radians $angle color $color filled $filled width $thickness layer $layer
   }
 }
 
@@ -106,17 +106,17 @@ When /someone/ wishes /p/ draws an /shape/ with /...options/ {
 }
 
 proc shift_region {region direction pct} {
-    set pct [expr {[string map {% ""} $pct] / 100.0}]
-    set w [region width $region]
-    set h [region height $region]
-    
-    switch $direction {
-        "right" { region move $region right [expr {$w * $pct}]px }
-        "left"  { region move $region left [expr {$w * $pct}]px }
-        "up"    { region move $region up [expr {$h * $pct}]px }
-        "down"  { region move $region down [expr {$h * $pct}]px }
-        default { region move $region right [expr {$w * $pct}]px }
-    }
+  set pct [expr {[string map {% ""} $pct] / 100.0}]
+  set w [region width $region]
+  set h [region height $region]
+
+  switch $direction {
+    "right" { region move $region right [expr {$w * $pct}]px }
+    "left"  { region move $region left [expr {$w * $pct}]px }
+    "up"    { region move $region up [expr {$h * $pct}]px }
+    "down"  { region move $region down [expr {$h * $pct}]px }
+    default { region move $region right [expr {$w * $pct}]px }
+  }
 }
 
 When /someone/ wishes /p/ draws a rect with width /w/ height /h/ shift /direction/ /pct/ {
@@ -131,11 +131,11 @@ When /someone/ wishes /p/ draws a /shape/ with radius /rad/ shift /direction/ /p
   When $p has region /r/ {
     set shifted [shift_region $r $direction $pct]
     lassign [region centroid $shifted] cx cy
-    
+
     if {[dict exists $shapes $shape]} {
-        Wish to draw a shape with sides [dict get $shapes $shape] center [list $cx $cy] radius $rad color white
+      Wish to draw a shape with sides [dict get $shapes $shape] center [list $cx $cy] radius $rad color white
     } else {
-        Wish $p draws a $shape with center [list $cx $cy] radius $rad color white
+      Wish $p draws a $shape with center [list $cx $cy] radius $rad color white
     }
   }
 }
@@ -153,86 +153,86 @@ When /someone/ wishes /p/ draws a /shape/ with radius /rad/ {
 }
 
 proc get_transform_info {region} {
-    set angle [region angle $region]
-    set center [region centroid $region]
-    return [list $center $angle]
+  set angle [region angle $region]
+  set center [region centroid $region]
+  return [list $center $angle]
 }
 
 proc transform_points {points center angle} {
-    set transformedPoints {}
-    foreach point $points {
-        lappend transformedPoints [vec2 add $center [vec2 rotate $point $angle]]
-    }
-    return $transformedPoints
+  set transformedPoints {}
+  foreach point $points {
+    lappend transformedPoints [vec2 add $center [vec2 rotate $point $angle]]
+  }
+  return $transformedPoints
 }
 
 When /someone/ wishes /page/ draws a set of points /points/ with /...options/ & /page/ has region /r/ {
-    set radius [dict_getdef $options radius 5]
-    set color [dict_getdef $options color white]
-    set filled [dict_getdef $options filled true]
-    set thickness [dict_getdef $options thickness 2]
-    set layer [dict_getdef $options layer 0]
-    
-    lassign [get_transform_info $r] center angle
-    
-    foreach point [transform_points $points $center $angle] {
-        Wish to draw a circle with center $point radius $radius thickness $thickness \
-            color $color filled $filled layer $layer
-    }
+  set radius [dict_getdef $options radius 5]
+  set color [dict_getdef $options color white]
+  set filled [dict_getdef $options filled true]
+  set thickness [dict_getdef $options thickness 2]
+  set layer [dict_getdef $options layer 0]
+
+  lassign [get_transform_info $r] center angle
+
+  foreach point [transform_points $points $center $angle] {
+    Wish to draw a circle with center $point radius $radius thickness $thickness \
+      color $color filled $filled layer $layer
+  }
 }
 
 When /someone/ wishes /page/ draws a polyline /points/ with /...options/ & /page/ has region /r/ {
-    set color [dict_getdef $options color white]
-    set thickness [dict_getdef $options thickness 2]
-    set layer [dict_getdef $options layer 0]
-    set dashed [dict_getdef $options dashed false]
-    set dashlength [dict_getdef $options dashlength 20]
-    set dashoffset [dict_getdef $options dashoffset 0]
-    
-    lassign [get_transform_info $r] center angle
-    set transformedPoints [transform_points $points $center $angle]
-    
-    if {$dashed} {
-        Wish to draw a dashed stroke with points $transformedPoints color $color width $thickness \
-            dashlength $dashlength dashoffset $dashoffset layer $layer
-    } else {
-        Wish to draw a stroke with points $transformedPoints color $color width $thickness layer $layer
-    }
+  set color [dict_getdef $options color white]
+  set thickness [dict_getdef $options thickness 2]
+  set layer [dict_getdef $options layer 0]
+  set dashed [dict_getdef $options dashed false]
+  set dashlength [dict_getdef $options dashlength 20]
+  set dashoffset [dict_getdef $options dashoffset 0]
+
+  lassign [get_transform_info $r] center angle
+  set transformedPoints [transform_points $points $center $angle]
+
+  if {$dashed} {
+    Wish to draw a dashed stroke with points $transformedPoints color $color width $thickness \
+      dashlength $dashlength dashoffset $dashoffset layer $layer
+  } else {
+    Wish to draw a stroke with points $transformedPoints color $color width $thickness layer $layer
+  }
 }
 
 Claim $this has demo {
   # Center circle
   Wish $this draws a circle
-  
+
   # Grid of shapes with varying thickness
   set baseX -850
   set baseY -200
   set gridSpacing 130
-  
+
   # Row 1: Regular polygons with different colors and thickness
   Wish $this draws a triangle with color skyblue width 2 offset [list $baseX [expr {$baseY}]]
   Wish $this draws a square with color green width 4 offset [list [expr {$baseX + $gridSpacing}] [expr {$baseY}]]
   Wish $this draws a pentagon with color gold width 6 offset [list [expr {$baseX + $gridSpacing*2}] [expr {$baseY}]]
   Wish $this draws a hexagon with color orange width 8 offset [list [expr {$baseX + $gridSpacing*3}] [expr {$baseY}]]
-  
+
   # Row 2: Filled shapes
   Wish $this draws a triangle with color skyblue filled true offset [list $baseX [expr {$baseY + $gridSpacing}]]
   Wish $this draws a square with color green filled true offset [list [expr {$baseX + $gridSpacing}] [expr {$baseY + $gridSpacing}]]
   Wish $this draws a pentagon with color gold filled true offset [list [expr {$baseX + $gridSpacing*2}] [expr {$baseY + $gridSpacing}]]
   Wish $this draws a hexagon with color orange filled true offset [list [expr {$baseX + $gridSpacing*3}] [expr {$baseY + $gridSpacing}]]
-  
+
   # Row 3: Shifting examples
   Wish $this draws a triangle with radius 40 shift right 50%
   Wish $this draws a square with radius 40 shift left 50%
   Wish $this draws a pentagon with radius 40 shift up 50%
   Wish $this draws a hexagon with radius 40 shift down 50%
-  
+
   # Row 4: Rectangles with different properties
   Wish $this draws a rect with width 80 height 50 color cyan thickness 3 offset [list $baseX [expr {$baseY + $gridSpacing*3}]]
   Wish $this draws a rect with width 80 height 50 color magenta filled true offset [list [expr {$baseX + $gridSpacing}] [expr {$baseY + $gridSpacing*3}]]
   Wish $this draws a rect with width 80 height 50 shift right 50%
   Wish $this draws a rect with width 80 height 50 shift left 50%
-  
+
   # Animated elements
   When the clock time is /t/ {
     set offsetVector [list [sin $t] [cos $t]]

--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -152,6 +152,54 @@ When /someone/ wishes /p/ draws a /shape/ with radius /rad/ {
   }
 }
 
+proc get_transform_info {region} {
+    set angle [region angle $region]
+    set center [region centroid $region]
+    return [list $center $angle]
+}
+
+proc transform_points {points center angle} {
+    set transformedPoints {}
+    foreach point $points {
+        lappend transformedPoints [vec2 add $center [vec2 rotate $point $angle]]
+    }
+    return $transformedPoints
+}
+
+When /someone/ wishes /page/ draws a set of points /points/ with /...options/ & /page/ has region /r/ {
+    set radius [dict_getdef $options radius 5]
+    set color [dict_getdef $options color white]
+    set filled [dict_getdef $options filled true]
+    set thickness [dict_getdef $options thickness 2]
+    set layer [dict_getdef $options layer 0]
+    
+    lassign [get_transform_info $r] center angle
+    
+    foreach point [transform_points $points $center $angle] {
+        Wish to draw a circle with center $point radius $radius thickness $thickness \
+            color $color filled $filled layer $layer
+    }
+}
+
+When /someone/ wishes /page/ draws a polyline /points/ with /...options/ & /page/ has region /r/ {
+    set color [dict_getdef $options color white]
+    set thickness [dict_getdef $options thickness 2]
+    set layer [dict_getdef $options layer 0]
+    set dashed [dict_getdef $options dashed false]
+    set dashlength [dict_getdef $options dashlength 20]
+    set dashoffset [dict_getdef $options dashoffset 0]
+    
+    lassign [get_transform_info $r] center angle
+    set transformedPoints [transform_points $points $center $angle]
+    
+    if {$dashed} {
+        Wish to draw a dashed stroke with points $transformedPoints color $color width $thickness \
+            dashlength $dashlength dashoffset $dashoffset layer $layer
+    } else {
+        Wish to draw a stroke with points $transformedPoints color $color width $thickness layer $layer
+    }
+}
+
 Claim $this has demo {
   # Center circle
   Wish $this draws a circle

--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -4,7 +4,7 @@ When /someone/ wishes to draw a shape with /...options/ {
   set numPoints [dict get $options sides]
   set c [dict get $options center]
   set r [dict get $options radius]
-  set radians [dict_getdef $options radians 0]
+  set angle [dict_getdef $options angle 0]
   set color [dict_getdef $options color white]
   set filled [dict_getdef $options filled false]
   set layer [dict_getdef $options layer 0]
@@ -23,7 +23,7 @@ When /someone/ wishes to draw a shape with /...options/ {
   }
 
   set points [lmap v $points {
-    vec2 add [vec2 rotate [vec2 sub $v [vec2 scale $centerPoint [expr {1.0/$numPoints}]]] $radians] $c
+    vec2 add [vec2 rotate [vec2 sub $v [vec2 scale $centerPoint [expr {1.0/$numPoints}]]] $angle] $c
     }]
 
     if {$filled} {
@@ -37,10 +37,10 @@ When /someone/ wishes to draw a rect with /...options/ {
   set c [dict get $options center]
   set w [dict_getdef $options width 100]
   set h [dict_getdef $options height 100]
-  set radians [dict_getdef $options radians 0]
+  set angle [dict_getdef $options angle 0]
   set color [dict_getdef $options color white]
   set filled [dict_getdef $options filled false]
-  set width [dict_getdef $options strokeWidth 1]
+  set width [dict_getdef $options thickness 1]
   set layer [dict_getdef $options layer 0]
 
   set hw [expr {$w / 2.0}]
@@ -53,7 +53,7 @@ When /someone/ wishes to draw a rect with /...options/ {
     [list [expr {-$hw}] [expr {$hh}]] \
     [list [expr {-$hw}] [expr {-$hh}]] \
     ] {
-      vec2 add [vec2 rotate $v $radians] $c
+      vec2 add [vec2 rotate $v $angle] $c
     }]
 
   if {$filled} {
@@ -90,14 +90,14 @@ When /someone/ wishes /p/ draws a /shape/ with /...options/ & /p/ has region /r/
   } elseif {$shape eq "rect"} {
     set w [dict_getdef $options width [region width $r]]
     set h [dict_getdef $options height [region height $r]]
-    Wish to draw a rect with center $center width $w height $h radians $angle \
+    Wish to draw a rect with center $center width $w height $h angle $angle \
       color $color filled $filled thickness $thickness layer $layer
   } elseif {[dict exists $shapes $shape]} {
     Wish to draw a shape with sides [dict get $shapes $shape] center $center radius $radius \
-      radians $angle color $color filled $filled width $thickness layer $layer
+      angle $angle color $color filled $filled width $thickness layer $layer
   } else {
     Wish to draw a shape with sides 2 center $center radius $radius \
-      radians $angle color $color filled $filled width $thickness layer $layer
+      angle $angle color $color filled $filled width $thickness layer $layer
   }
 }
 
@@ -123,7 +123,7 @@ When /someone/ wishes /p/ draws a rect with width /w/ height /h/ shift /directio
   When $p has region /r/ {
     set shifted [shift_region $r $direction $pct]
     lassign [region centroid $shifted] cx cy
-    Wish to draw a rect with center [list $cx $cy] width $w height $h radians [region angle $r] color white
+    Wish to draw a rect with center [list $cx $cy] width $w height $h angle [region angle $r] color white
   }
 }
 
@@ -141,7 +141,7 @@ When /someone/ wishes /p/ draws a /shape/ with radius /rad/ shift /direction/ /p
 }
 
 When /someone/ wishes /p/ draws a rect with width /w/ height /h/ {
-  Wish to draw a rect with center {0 0} width $w height $h radians 0 color white
+  Wish to draw a rect with center {0 0} width $w height $h angle 0 color white
 }
 
 When /someone/ wishes /p/ draws a /shape/ with radius /rad/ {

--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -1,65 +1,160 @@
 set shapes [dict create triangle 3 square 4 pentagon 5 hexagon 6 septagon 7 octagon 8 nonagon 9]
 
-When /someone/ wishes to draw a shape with /...options/ {
-  set numPoints [dict get $options sides]
-  set c [dict get $options center]
-  set r [dict get $options radius]
-  set angle [dict_getdef $options angle 0]
-  set color [dict_getdef $options color white]
-  set filled [dict_getdef $options filled false]
-  set layer [dict_getdef $options layer 0]
-  set width [dict_getdef $options width 1]
-
-  set points {{0 0}}
-  set centerPoint {0 0}
-  set angle [expr {2 * 3.14159 / $numPoints + 3.14159}]
-  set angleIncr [expr {2 * 3.14159 / $numPoints}]
-
-  for {set i 0} {$i < $numPoints} {incr i} {
-    set p [vec2 add [lindex $points end] [vec2 scale [list [expr {cos($angle)}] [expr {sin($angle)}]] $r]]
-    lappend points $p
-    set centerPoint [vec2 add $centerPoint $p]
-    set angle [expr {$angle + $angleIncr}]
+proc process_offset {offset region} {
+  if {![info exists region]} {
+    return $offset
   }
-
-  set points [lmap v $points {
-    vec2 add [vec2 rotate [vec2 sub $v [vec2 scale $centerPoint [expr {1.0/$numPoints}]]] $angle] $c
-    }]
-
-    if {$filled} {
-      Wish to draw a polygon with points $points color $color layer $layer
-    } else {
-      Wish to draw a stroke with points $points width $width color $color layer $layer
+  
+  set w [region width $region]
+  set h [region height $region]
+  
+  if {[llength $offset] == 2 && 
+      ![string match *%* $offset] && 
+      ![string is alpha -strict [lindex $offset 0]]} {
+    return $offset
+  }
+  
+  # Handle simple percentage string: "50%"
+  if {[string match *%* $offset] && [llength $offset] == 1} {
+    set pct [expr {[string map {% ""} $offset] / 100.0}]
+    return [list [expr {$w * $pct}] 0]  # Default to horizontal offset
+  }
+  
+  # Handle directional strings: "right", "left", "up", "down"
+  if {$offset eq "right"} {
+    return [list [expr {$w * 0.5}] 0]
+  } elseif {$offset eq "left"} {
+    return [list [expr {-$w * 0.5}] 0]
+  } elseif {$offset eq "up"} {
+    return [list 0 [expr {-$h * 0.5}]]
+  } elseif {$offset eq "down"} {
+    return [list 0 [expr {$h * 0.5}]]
+  }
+  
+  # Handle directional percentage: "right 50%", "left 25%", etc.
+  if {[llength $offset] == 2 && [string is alpha -strict [lindex $offset 0]]} {
+    set direction [lindex $offset 0]
+    set amount [lindex $offset 1]
+    
+    if {[string match *%* $amount]} {
+      set pct [expr {[string map {% ""} $amount] / 100.0}]
+      
+      switch $direction {
+        "right" { return [list [expr {$w * $pct}] 0] }
+        "left"  { return [list [expr {-$w * $pct}] 0] }
+        "up"    { return [list 0 [expr {-$h * $pct}]] }
+        "down"  { return [list 0 [expr {$h * $pct}]] }
+        default { return [list 0 0] }
+      }
     }
   }
+  
+  # Handle x y vector where one or both components have percentage notation
+  if {[llength $offset] == 2} {
+    lassign $offset ox oy
+    
+    if {[string match *%* $ox]} {
+      set pct [expr {[string map {% ""} $ox] / 100.0}]
+      set ox [expr {$w * $pct}]
+    }
+    
+    if {[string match *%* $oy]} {
+      set pct [expr {[string map {% ""} $oy] / 100.0}]
+      set oy [expr {$h * $pct}]
+    }
+    
+    return [list $ox $oy]
+  }
+  
+  # Default fallback
+  return $offset
+}
 
-When /someone/ wishes to draw a rect with /...options/ {
-  set c [dict get $options center]
-  set w [dict_getdef $options width 100]
-  set h [dict_getdef $options height 100]
-  set angle [dict_getdef $options angle 0]
+When /someone/ wishes to draw a shape with /...options/ {
+  set isRect 0
+  if {[dict exists $options type] && [dict get $options type] eq "rect"} {
+    set isRect 1
+  }
+  
+  set c [dict_getdef $options center {0 0}]
+  
   set color [dict_getdef $options color white]
   set filled [dict_getdef $options filled false]
-  set width [dict_getdef $options thickness 1]
+  set thickness [dict_getdef $options thickness 1]
   set layer [dict_getdef $options layer 0]
-
-  set hw [expr {$w / 2.0}]
-  set hh [expr {$h / 2.0}]
-
-  set points [lmap v [list \
-    [list [expr {-$hw}] [expr {-$hh}]] \
-    [list [expr {$hw}] [expr {-$hh}]] \
-    [list [expr {$hw}] [expr {$hh}]] \
-    [list [expr {-$hw}] [expr {$hh}]] \
-    [list [expr {-$hw}] [expr {-$hh}]] \
+  set angle [dict_getdef $options angle 0]
+  
+  if {$isRect} {
+    set w [dict_getdef $options width 100]
+    set h [dict_getdef $options height 100]
+    
+    set hw [expr {$w / 2.0}]
+    set hh [expr {$h / 2.0}]
+    
+    set points [lmap v [list \
+      [list [expr {-$hw}] [expr {-$hh}]] \
+      [list [expr {$hw}] [expr {-$hh}]] \
+      [list [expr {$hw}] [expr {$hh}]] \
+      [list [expr {-$hw}] [expr {$hh}]] \
+      [list [expr {-$hw}] [expr {-$hh}]] \
     ] {
       vec2 add [vec2 rotate $v $angle] $c
     }]
-
+  } else {
+    set numPoints [dict_getdef $options sides 4]
+    if {[dict exists $options shape] && [dict exists $shapes [dict get $options shape]]} {
+      set numPoints [dict get $shapes [dict get $options shape]]
+    }
+    set r [dict_getdef $options radius 50]
+    
+    set points {{0 0}}
+    set centerPoint {0 0}
+    set polyAngle [expr {2 * 3.14159 / $numPoints + 3.14159}]
+    set angleIncr [expr {2 * 3.14159 / $numPoints}]
+    
+    for {set i 0} {$i < $numPoints} {incr i} {
+      set p [vec2 add [lindex $points end] [vec2 scale [list [expr {cos($polyAngle)}] [expr {sin($polyAngle)}]] $r]]
+      lappend points $p
+      set centerPoint [vec2 add $centerPoint $p]
+      set polyAngle [expr {$polyAngle + $angleIncr}]
+    }
+    
+    set points [lmap v $points {
+      vec2 add [vec2 rotate [vec2 sub $v [vec2 scale $centerPoint [expr {1.0/$numPoints}]]] $angle] $c
+    }]
+  }
+  
   if {$filled} {
     Wish to draw a polygon with points $points color $color layer $layer
   } else {
-    Wish to draw a stroke with points $points width $width color $color layer $layer
+    Wish to draw a stroke with points $points width $thickness color $color layer $layer
+  }
+}
+
+When /someone/ wishes to draw a circle with /...options/ {
+  set center [dict_getdef $options center {0 0}]
+  set radius [dict_getdef $options radius 50]
+  set color [dict_getdef $options color white]
+  set thickness [dict_getdef $options thickness 2]
+  set filled [dict_getdef $options filled false]
+  set layer [dict_getdef $options layer 0]
+  
+  set numPoints 36
+  set points {}
+  
+  for {set i 0} {$i < $numPoints} {incr i} {
+    set angle [expr {2 * 3.14159 * $i / $numPoints}]
+    set x [expr {$radius * cos($angle)}]
+    set y [expr {$radius * sin($angle)}]
+    lappend points [vec2 add [list $x $y] $center]
+  }
+  
+  lappend points [lindex $points 0]
+  
+  if {$filled} {
+    Wish to draw a polygon with points $points color $color layer $layer
+  } else {
+    Wish to draw a stroke with points $points width $thickness color $color layer $layer
   }
 }
 
@@ -67,6 +162,7 @@ When /someone/ wishes /p/ draws a /shape/ {
   Wish $p draws a $shape with color white
 }
 
+# Handle "a" vs "an" grammar variations
 When /someone/ wishes /p/ draws an /shape/ {
   Wish $p draws a $shape
 }
@@ -74,96 +170,55 @@ When /someone/ wishes /p/ draws an /shape/ {
 When /someone/ wishes /p/ draws a /shape/ with /...options/ & /p/ has region /r/ {
   lassign [region centroid $r] cx cy
   set angle [region angle $r]
-
-  set radius [dict_getdef $options radius 50]
+  
   set color [dict_getdef $options color white]
   set filled [dict_getdef $options filled false]
   set thickness [dict_getdef $options thickness 5]
   set layer [dict_getdef $options layer 0]
-
-  lassign [dict_getdef $options offset {0 0}] ox oy
-  set center [vec2 add [list $cx $cy] [vec2 rotate [list $ox $oy] $angle]]
-
+  
+  set offset [dict_getdef $options offset {0 0}]
+  set offset [process_offset $offset $r]
+  
+  set center [vec2 add [list $cx $cy] [vec2 rotate $offset $angle]]
+  
   if {$shape eq "circle"} {
+    set radius [dict_getdef $options radius 50]
+    
     Wish to draw a circle with center $center radius $radius thickness $thickness \
       color $color filled $filled layer $layer
+      
   } elseif {$shape eq "rect"} {
     set w [dict_getdef $options width [region width $r]]
     set h [dict_getdef $options height [region height $r]]
-    Wish to draw a rect with center $center width $w height $h angle $angle \
+    
+    Wish to draw a shape with type rect center $center width $w height $h angle $angle \
       color $color filled $filled thickness $thickness layer $layer
+      
   } elseif {[dict exists $shapes $shape]} {
+    set radius [dict_getdef $options radius 50]
+    
     Wish to draw a shape with sides [dict get $shapes $shape] center $center radius $radius \
-      angle $angle color $color filled $filled width $thickness layer $layer
+      angle $angle color $color filled $filled thickness $thickness layer $layer
+      
   } else {
-    Wish to draw a shape with sides 2 center $center radius $radius \
-      angle $angle color $color filled $filled width $thickness layer $layer
+    set radius [dict_getdef $options radius 50]
+    
+    Wish to draw a shape with sides 4 center $center radius $radius \
+      angle $angle color $color filled $filled thickness $thickness layer $layer
   }
 }
 
+# Pass through options for "an" version
 When /someone/ wishes /p/ draws an /shape/ with /...options/ {
   Wish $p draws a $shape with {*}$options
 }
 
-proc shift_region {region direction pct} {
-  set pct [expr {[string map {% ""} $pct] / 100.0}]
-  set w [region width $region]
-  set h [region height $region]
-
-  switch $direction {
-    "right" { region move $region right [expr {$w * $pct}]px }
-    "left"  { region move $region left [expr {$w * $pct}]px }
-    "up"    { region move $region up [expr {$h * $pct}]px }
-    "down"  { region move $region down [expr {$h * $pct}]px }
-    default { region move $region right [expr {$w * $pct}]px }
-  }
-}
-
-When /someone/ wishes /p/ draws a rect with width /w/ height /h/ shift /direction/ /pct/ {
-  When $p has region /r/ {
-    set shifted [shift_region $r $direction $pct]
-    lassign [region centroid $shifted] cx cy
-    Wish to draw a rect with center [list $cx $cy] width $w height $h angle [region angle $r] color white
-  }
-}
-
-When /someone/ wishes /p/ draws a /shape/ with radius /rad/ shift /direction/ /pct/ {
-  When $p has region /r/ {
-    set shifted [shift_region $r $direction $pct]
-    lassign [region centroid $shifted] cx cy
-
-    if {[dict exists $shapes $shape]} {
-      Wish to draw a shape with sides [dict get $shapes $shape] center [list $cx $cy] radius $rad color white
-    } else {
-      Wish $p draws a $shape with center [list $cx $cy] radius $rad color white
-    }
-  }
-}
-
 When /someone/ wishes /p/ draws a rect with width /w/ height /h/ {
-  Wish to draw a rect with center {0 0} width $w height $h angle 0 color white
+  Wish $p draws a rect with width $w height $h
 }
 
 When /someone/ wishes /p/ draws a /shape/ with radius /rad/ {
-  if {[dict exists $shapes $shape]} {
-    Wish to draw a shape with sides [dict get $shapes $shape] center {0 0} radius $rad color white
-  } else {
-    Wish to draw a $shape with center {0 0} radius $rad color white
-  }
-}
-
-proc get_transform_info {region} {
-  set angle [region angle $region]
-  set center [region centroid $region]
-  return [list $center $angle]
-}
-
-proc transform_points {points center angle} {
-  set transformedPoints {}
-  foreach point $points {
-    lappend transformedPoints [vec2 add $center [vec2 rotate $point $angle]]
-  }
-  return $transformedPoints
+  Wish $p draws a $shape with radius $rad
 }
 
 When /someone/ wishes /page/ draws a set of points /points/ with /...options/ & /page/ has region /r/ {
@@ -172,11 +227,21 @@ When /someone/ wishes /page/ draws a set of points /points/ with /...options/ & 
   set filled [dict_getdef $options filled true]
   set thickness [dict_getdef $options thickness 2]
   set layer [dict_getdef $options layer 0]
-
-  lassign [get_transform_info $r] center angle
-
-  foreach point [transform_points $points $center $angle] {
-    Wish to draw a circle with center $point radius $radius thickness $thickness \
+  
+  lassign [region centroid $r] cx cy
+  set angle [region angle $r]
+  set center [list $cx $cy]
+  
+  if {[dict exists $options offset]} {
+    set offset [dict get $options offset]
+    set offset [process_offset $offset $r]
+    set center [vec2 add $center [vec2 rotate $offset $angle]]
+  }
+  
+  foreach point $points {
+    set pointPos [vec2 add $center [vec2 rotate $point $angle]]
+    
+    Wish to draw a circle with center $pointPos radius $radius thickness $thickness \
       color $color filled $filled layer $layer
   }
 }
@@ -188,10 +253,22 @@ When /someone/ wishes /page/ draws a polyline /points/ with /...options/ & /page
   set dashed [dict_getdef $options dashed false]
   set dashlength [dict_getdef $options dashlength 20]
   set dashoffset [dict_getdef $options dashoffset 0]
-
-  lassign [get_transform_info $r] center angle
-  set transformedPoints [transform_points $points $center $angle]
-
+  
+  lassign [region centroid $r] cx cy
+  set angle [region angle $r]
+  set center [list $cx $cy]
+  
+  if {[dict exists $options offset]} {
+    set offset [dict get $options offset]
+    set offset [process_offset $offset $r]
+    set center [vec2 add $center [vec2 rotate $offset $angle]]
+  }
+  
+  set transformedPoints {}
+  foreach point $points {
+    lappend transformedPoints [vec2 add $center [vec2 rotate $point $angle]]
+  }
+  
   if {$dashed} {
     Wish to draw a dashed stroke with points $transformedPoints color $color width $thickness \
       dashlength $dashlength dashoffset $dashoffset layer $layer
@@ -203,49 +280,49 @@ When /someone/ wishes /page/ draws a polyline /points/ with /...options/ & /page
 Claim $this has demo {
   # Center circle
   Wish $this draws a circle
-
+  
   # Grid of shapes with varying thickness
   set baseX -850
   set baseY -200
   set gridSpacing 130
-
+  
   # Row 1: Regular polygons with different colors and thickness
-  Wish $this draws a triangle with color skyblue width 2 offset [list $baseX [expr {$baseY}]]
-  Wish $this draws a square with color green width 4 offset [list [expr {$baseX + $gridSpacing}] [expr {$baseY}]]
-  Wish $this draws a pentagon with color gold width 6 offset [list [expr {$baseX + $gridSpacing*2}] [expr {$baseY}]]
-  Wish $this draws a hexagon with color orange width 8 offset [list [expr {$baseX + $gridSpacing*3}] [expr {$baseY}]]
-
+  Wish $this draws a triangle with color skyblue thickness 2 offset [list $baseX [expr {$baseY}]]
+  Wish $this draws a square with color green thickness 4 offset [list [expr {$baseX + $gridSpacing}] [expr {$baseY}]]
+  Wish $this draws a pentagon with color gold thickness 6 offset [list [expr {$baseX + $gridSpacing*2}] [expr {$baseY}]]
+  Wish $this draws a hexagon with color orange thickness 8 offset [list [expr {$baseX + $gridSpacing*3}] [expr {$baseY}]]
+  
   # Row 2: Filled shapes
   Wish $this draws a triangle with color skyblue filled true offset [list $baseX [expr {$baseY + $gridSpacing}]]
   Wish $this draws a square with color green filled true offset [list [expr {$baseX + $gridSpacing}] [expr {$baseY + $gridSpacing}]]
   Wish $this draws a pentagon with color gold filled true offset [list [expr {$baseX + $gridSpacing*2}] [expr {$baseY + $gridSpacing}]]
   Wish $this draws a hexagon with color orange filled true offset [list [expr {$baseX + $gridSpacing*3}] [expr {$baseY + $gridSpacing}]]
-
-  # Row 3: Shifting examples
-  Wish $this draws a triangle with radius 40 shift right 50%
-  Wish $this draws a square with radius 40 shift left 50%
-  Wish $this draws a pentagon with radius 40 shift up 50%
-  Wish $this draws a hexagon with radius 40 shift down 50%
-
+  
+  # Row 3: Directional offset examples (replacing shift)
+  Wish $this draws a triangle with radius 40 offset "right 50%"
+  Wish $this draws a square with radius 40 offset  "left 50%"
+  Wish $this draws a pentagon with radius 40 offset "up 50%"
+  Wish $this draws a hexagon with radius 40 offset "down 50%"
+  
   # Row 4: Rectangles with different properties
   Wish $this draws a rect with width 80 height 50 color cyan thickness 3 offset [list $baseX [expr {$baseY + $gridSpacing*3}]]
   Wish $this draws a rect with width 80 height 50 color magenta filled true offset [list [expr {$baseX + $gridSpacing}] [expr {$baseY + $gridSpacing*3}]]
-  Wish $this draws a rect with width 80 height 50 shift right 50%
-  Wish $this draws a rect with width 80 height 50 shift left 50%
-
+  Wish $this draws a rect with width 80 height 50 offset "right 50%"
+  Wish $this draws a rect with width 80 height 50 offset  "left 50%"
+  
   # Animated elements
   When the clock time is /t/ {
     set offsetVector [list [sin $t] [cos $t]]
     set offsetVector [::vec2::scale $offsetVector 105]
     Wish $this draws a circle with color palegoldenrod offset $offsetVector
   }
-
+  
   When $this has region /r/ & the clock time is /t/ {
     lassign [region centroid $r] x y
     set fill [expr {round(sin($t) * 2) % 2 == 0}]
     set y [- $y 150]
-    Wish to draw a square with center [list [- $x 100] $y] radius 60 color white filled $fill
+    Wish to draw a shape with sides 4 center [list [- $x 100] $y] radius 60 color white filled $fill
   }
-
+  
   Wish $this is outlined white
 }

--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -131,33 +131,6 @@ When /someone/ wishes to draw a shape with /...options/ {
   }
 }
 
-When /someone/ wishes to draw a circle with /...options/ {
-  set center [dict_getdef $options center {0 0}]
-  set radius [dict_getdef $options radius 50]
-  set color [dict_getdef $options color white]
-  set thickness [dict_getdef $options thickness 2]
-  set filled [dict_getdef $options filled false]
-  set layer [dict_getdef $options layer 0]
-  
-  set numPoints 36
-  set points {}
-  
-  for {set i 0} {$i < $numPoints} {incr i} {
-    set angle [expr {2 * 3.14159 * $i / $numPoints}]
-    set x [expr {$radius * cos($angle)}]
-    set y [expr {$radius * sin($angle)}]
-    lappend points [vec2 add [list $x $y] $center]
-  }
-  
-  lappend points [lindex $points 0]
-  
-  if {$filled} {
-    Wish to draw a polygon with points $points color $color layer $layer
-  } else {
-    Wish to draw a stroke with points $points width $thickness color $color layer $layer
-  }
-}
-
 When /someone/ wishes /p/ draws a /shape/ {
   Wish $p draws a $shape with color white
 }

--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -1,6 +1,8 @@
-# sides 2 => line
-# sides 3 => triangle
-# sides 4 => square
+# Dictionary mapping shape names to number of sides
+set shapes [dict create triangle 3 square 4 pentagon 5 hexagon 6 \
+                septagon 7 octagon 8 nonagon 9]
+
+# Core shape drawing function - creates regular polygons
 When /someone/ wishes to draw a shape with /...options/ {
   set numPoints [dict get $options sides]
   set c [dict get $options center]
@@ -9,9 +11,10 @@ When /someone/ wishes to draw a shape with /...options/ {
   set color [dict_getdef $options color white]
   set filled [dict_getdef $options filled false]
   set layer [dict_getdef $options layer 0]
+  set width [dict_getdef $options width 1]
 
   set p [list 0 0]
-  set center $p
+  set centerPoint $p
   set points [list $p]
 
   set incr [expr {2 * 3.14159 / $numPoints}]
@@ -19,14 +22,13 @@ When /someone/ wishes to draw a shape with /...options/ {
   for {set i 0} {$i < $numPoints} {incr i} {
     set p [vec2 add $p [vec2 scale [list [expr {cos($a)}] [expr {sin($a)}]] $r]]
     lappend points $p
-    # Accumulate center
-    set center [vec2 add $center $p]
+    set centerPoint [vec2 add $centerPoint $p]
     set a [expr {$a + $incr}]
   }
-  set center [vec2 scale $center [expr {1.0/$numPoints}]]
+  set centerPoint [vec2 scale $centerPoint [expr {1.0/$numPoints}]]
 
   set points [lmap v $points {
-      set v [vec2 sub $v $center]
+      set v [vec2 sub $v $centerPoint]
       set v [vec2 rotate $v $radians]
       set v [vec2 add $v $c]
       set v
@@ -35,37 +37,38 @@ When /someone/ wishes to draw a shape with /...options/ {
   if {$filled} {
     Wish to draw a polygon with points $points color $color layer $layer
   } else {
-    Wish to draw a stroke with points $points width 1 color $color layer $layer
+    Wish to draw a stroke with points $points width $width color $color layer $layer
   }
 }
 
-set shapes [dict create triangle 3 square 4 pentagon 5 hexagon 6 \
-                septagon 7 octagon 8 nonagon 9]
 When /someone/ wishes /p/ draws a /shape/ {
-  # TODO: This is a hack because rest pattern doesn't match empty
-  # sequence at end.
   Wish $p draws a $shape with color white
 }
-When /someone/ wishes /p/ draws an /shape/ { Wish $p draws a $shape }
+
+When /someone/ wishes /p/ draws an /shape/ {
+  Wish $p draws a $shape
+}
+
 When /someone/ wishes /p/ draws a /shape/ with /...options/ & /p/ has region /r/ {
+  # Get the region's properties
   lassign [region centroid $r] cx cy
   set angle [region angle $r]
   
-  set width [region width $r]
-  set height [region height $r]
+  # Extract parameters
   set radius [dict_getdef $options radius 50]
   set color [dict_getdef $options color white]
   set filled [dict_getdef $options filled false]
   set thickness [dict_getdef $options thickness 5]
   set layer [dict_getdef $options layer 0]
   
+  # Rotate offset vector by region's angle for consistent positioning
   lassign [dict_getdef $options offset {0 0}] offsetX offsetY
-  set rawOffset [list $offsetX $offsetY]
+  set rotatedOffset [vec2 rotate [list $offsetX $offsetY] $angle]
   
-  set rotatedOffset [vec2 rotate $rawOffset $angle]
-  
+  # Calculate final center position
   set finalCenter [vec2 add [list $cx $cy] $rotatedOffset]
 
+  # Draw appropriate shape
   if {$shape eq "circle"} {
       Wish to draw a circle with \
           center $finalCenter radius $radius thickness $thickness \
@@ -73,13 +76,14 @@ When /someone/ wishes /p/ draws a /shape/ with /...options/ & /p/ has region /r/
   } elseif {[dict exists $shapes $shape]} {
       Wish to draw a shape with sides [dict get $shapes $shape] \
           center $finalCenter radius $radius radians $angle \
-          color $color filled $filled layer $layer
+          color $color filled $filled width $thickness layer $layer
   } else {
       Wish to draw a shape with sides 2 \
           center $finalCenter radius $radius radians $angle \
-          color $color filled $filled layer $layer
+          color $color filled $filled width $thickness layer $layer
   }
 }
+
 When /someone/ wishes /p/ draws an /shape/ with /...options/ {
   Wish $p draws a $shape with {*}$options
 }
@@ -87,9 +91,9 @@ When /someone/ wishes /p/ draws an /shape/ with /...options/ {
 Claim $this has demo {
   Wish $this draws a circle
   Wish $this draws a triangle with color skyblue
-  Wish $this draws a triangle with color green offset {280 0}
-  Wish $this draws a pentagon with color gold offset {200 0}
-  Wish $this draws an octagon with color red offset {250 80}
+  Wish $this draws a triangle with color green offset {-280 0}
+  Wish $this draws a pentagon with color gold offset {-200 0}
+  Wish $this draws an octagon with color magenta offset {-250 80}
 
   When the clock time is /t/ {
     set offsetVector [list [sin $t] [cos $t]]

--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -119,7 +119,7 @@ proc shift_region {region direction pct} {
     }
 }
 
-When /someone/ wishes /p/ draw a rect with width /w/ height /h/ shift /direction/ /pct/ {
+When /someone/ wishes /p/ draws a rect with width /w/ height /h/ shift /direction/ /pct/ {
   When $p has region /r/ {
     set shifted [shift_region $r $direction $pct]
     lassign [region centroid $shifted] cx cy
@@ -127,7 +127,7 @@ When /someone/ wishes /p/ draw a rect with width /w/ height /h/ shift /direction
   }
 }
 
-When /someone/ wishes /p/ draw a /shape/ with radius /rad/ shift /direction/ /pct/ {
+When /someone/ wishes /p/ draws a /shape/ with radius /rad/ shift /direction/ /pct/ {
   When $p has region /r/ {
     set shifted [shift_region $r $direction $pct]
     lassign [region centroid $shifted] cx cy
@@ -140,11 +140,11 @@ When /someone/ wishes /p/ draw a /shape/ with radius /rad/ shift /direction/ /pc
   }
 }
 
-When /someone/ wishes /p/ draw a rect with width /w/ height /h/ {
+When /someone/ wishes /p/ draws a rect with width /w/ height /h/ {
   Wish to draw a rect with center {0 0} width $w height $h radians 0 color white
 }
 
-When /someone/ wishes /p/ draw a /shape/ with radius /rad/ {
+When /someone/ wishes /p/ draws a /shape/ with radius /rad/ {
   if {[dict exists $shapes $shape]} {
     Wish to draw a shape with sides [dict get $shapes $shape] center {0 0} radius $rad color white
   } else {
@@ -174,16 +174,16 @@ Claim $this has demo {
   Wish $this draws a hexagon with color orange filled true offset [list [expr {$baseX + $gridSpacing*3}] [expr {$baseY + $gridSpacing}]]
   
   # Row 3: Shifting examples
-  Wish $this draw a triangle with radius 40 shift right 50%
-  Wish $this draw a square with radius 40 shift left 50%
-  Wish $this draw a pentagon with radius 40 shift up 50%
-  Wish $this draw a hexagon with radius 40 shift down 50%
+  Wish $this draws a triangle with radius 40 shift right 50%
+  Wish $this draws a square with radius 40 shift left 50%
+  Wish $this draws a pentagon with radius 40 shift up 50%
+  Wish $this draws a hexagon with radius 40 shift down 50%
   
   # Row 4: Rectangles with different properties
   Wish $this draws a rect with width 80 height 50 color cyan thickness 3 offset [list $baseX [expr {$baseY + $gridSpacing*3}]]
   Wish $this draws a rect with width 80 height 50 color magenta filled true offset [list [expr {$baseX + $gridSpacing}] [expr {$baseY + $gridSpacing*3}]]
-  Wish $this draw a rect with width 80 height 50 shift right 50%
-  Wish $this draw a rect with width 80 height 50 shift left 50%
+  Wish $this draws a rect with width 80 height 50 shift right 50%
+  Wish $this draws a rect with width 80 height 50 shift left 50%
   
   # Animated elements
   When the clock time is /t/ {

--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -48,37 +48,35 @@ When /someone/ wishes /p/ draws a /shape/ {
 }
 When /someone/ wishes /p/ draws an /shape/ { Wish $p draws a $shape }
 When /someone/ wishes /p/ draws a /shape/ with /...options/ & /p/ has region /r/ {
-  lassign [region centroid $r] x y
+  lassign [region centroid $r] cx cy
+  set angle [region angle $r]
+  
   set width [region width $r]
   set height [region height $r]
-  lassign [dict_getdef $options offset {0 0}] offsetX offsetY
   set radius [dict_getdef $options radius 50]
   set color [dict_getdef $options color white]
   set filled [dict_getdef $options filled false]
   set thickness [dict_getdef $options thickness 5]
   set layer [dict_getdef $options layer 0]
- 
-  if {$offsetX != 0} {
-    set x [expr {$x + $offsetX}]
-  }
-  if {$offsetY != 0} {
-    set y [expr {$y + $offsetY}]
-  }
-
-  set angle [region angle $r]
-  set p [list $x $y]
+  
+  lassign [dict_getdef $options offset {0 0}] offsetX offsetY
+  set rawOffset [list $offsetX $offsetY]
+  
+  set rotatedOffset [vec2 rotate $rawOffset $angle]
+  
+  set finalCenter [vec2 add [list $cx $cy] $rotatedOffset]
 
   if {$shape eq "circle"} {
       Wish to draw a circle with \
-          center $p radius $radius thickness $thickness \
+          center $finalCenter radius $radius thickness $thickness \
           color $color filled $filled layer $layer
   } elseif {[dict exists $shapes $shape]} {
       Wish to draw a shape with sides [dict get $shapes $shape] \
-          center $p radius $radius radians $angle \
+          center $finalCenter radius $radius radians $angle \
           color $color filled $filled layer $layer
   } else {
       Wish to draw a shape with sides 2 \
-          center $p radius $radius radians $angle \
+          center $finalCenter radius $radius radians $angle \
           color $color filled $filled layer $layer
   }
 }

--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -193,7 +193,7 @@ Claim $this has demo {
   Wish $this draws a triangle with color skyblue
   Wish $this draws a triangle with color green offset {-280 0}
   Wish $this draws a pentagon with color gold offset {-200 0}
-  Wish $this draws an octagon with color magenta offset {-250 80}
+  Wish $this draws an octagon with color red offset {-250 80}
   
   # Rectangle examples
   Wish $this draws a rect with width 150 height 75 color cyan filled true offset {-250 -250}

--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -41,6 +41,41 @@ When /someone/ wishes to draw a shape with /...options/ {
   }
 }
 
+# Rectangle drawing function with rotation around regional center
+When /someone/ wishes to draw a rect with /...options/ {
+  set c [dict get $options center]
+  set width [dict_getdef $options width 100]
+  set height [dict_getdef $options height 100]
+  set radians [dict_getdef $options radians 0]
+  set color [dict_getdef $options color white]
+  set filled [dict_getdef $options filled false]
+  set strokeWidth [dict_getdef $options strokeWidth 1]
+  set layer [dict_getdef $options layer 0]
+  
+  set halfWidth [expr {$width / 2.0}]
+  set halfHeight [expr {$height / 2.0}]
+  
+  set points [list \
+      [list [expr {-$halfWidth}] [expr {-$halfHeight}]] \
+      [list [expr {$halfWidth}] [expr {-$halfHeight}]] \
+      [list [expr {$halfWidth}] [expr {$halfHeight}]] \
+      [list [expr {-$halfWidth}] [expr {$halfHeight}]] \
+      [list [expr {-$halfWidth}] [expr {-$halfHeight}]] \
+  ]
+  
+  set points [lmap v $points {
+      set v [vec2 rotate $v $radians]
+      set v [vec2 add $v $c]
+      set v
+  }]
+  
+  if {$filled} {
+      Wish to draw a polygon with points $points color $color layer $layer
+  } else {
+      Wish to draw a stroke with points $points width $strokeWidth color $color layer $layer
+  }
+}
+
 When /someone/ wishes /p/ draws a /shape/ {
   Wish $p draws a $shape with color white
 }
@@ -53,6 +88,8 @@ When /someone/ wishes /p/ draws a /shape/ with /...options/ & /p/ has region /r/
   # Get the region's properties
   lassign [region centroid $r] cx cy
   set angle [region angle $r]
+  set width [region width $r]
+  set height [region height $r]
   
   # Extract parameters
   set radius [dict_getdef $options radius 50]
@@ -73,19 +110,82 @@ When /someone/ wishes /p/ draws a /shape/ with /...options/ & /p/ has region /r/
       Wish to draw a circle with \
           center $finalCenter radius $radius thickness $thickness \
           color $color filled $filled layer $layer
+  } elseif {$shape eq "rect"} {
+      set rectWidth [dict_getdef $options width $width]
+      set rectHeight [dict_getdef $options height $height]
+      Wish to draw a rect with \
+          center $finalCenter width $rectWidth height $rectHeight radians $angle \
+          color $color filled $filled strokeWidth $thickness layer $layer
   } elseif {[dict exists $shapes $shape]} {
       Wish to draw a shape with sides [dict get $shapes $shape] \
           center $finalCenter radius $radius radians $angle \
           color $color filled $filled width $thickness layer $layer
   } else {
+      # Default to a line (2 sides) if shape not recognized
       Wish to draw a shape with sides 2 \
           center $finalCenter radius $radius radians $angle \
           color $color filled $filled width $thickness layer $layer
   }
 }
 
+# Handle "an" grammar variant with options
 When /someone/ wishes /p/ draws an /shape/ with /...options/ {
   Wish $p draws a $shape with {*}$options
+}
+
+# Specialized rectangle drawing with consistent positioning and rotation
+When /someone/ wishes /p/ draw a rect with width /w/ height /h/ shifted /direction/ /pct/ {
+  When $p has region /r/ {
+    # Get the region's properties
+    lassign [region centroid $r] cx cy
+    set angle [region angle $r]
+    
+    # Strip percentage sign if present and convert to decimal
+    set pctValue [string map {% ""} $pct]
+    set pctFraction [expr {$pctValue / 100.0}]
+    
+    # Determine the direction vector based on region width/height
+    set width [region width $r]
+    set offset 0
+    
+    if {$direction eq "right"} {
+      set offset [expr {$width * $pctFraction}]
+      set offsetVec [list $offset 0]
+    } elseif {$direction eq "left"} {
+      set offset [expr {-$width * $pctFraction}]
+      set offsetVec [list $offset 0]
+    } elseif {$direction eq "up"} {
+      set height [region height $r]
+      set offset [expr {-$height * $pctFraction}]
+      set offsetVec [list 0 $offset]
+    } elseif {$direction eq "down"} {
+      set height [region height $r]
+      set offset [expr {$height * $pctFraction}]
+      set offsetVec [list 0 $offset]
+    } else {
+      # Default to right if invalid direction
+      set offset [expr {$width * $pctFraction}]
+      set offsetVec [list $offset 0]
+    }
+    
+    # Rotate the offset vector based on region's angle
+    set rotatedOffset [vec2 rotate $offsetVec $angle]
+    
+    # Calculate final center position
+    set finalCenter [vec2 add [list $cx $cy] $rotatedOffset]
+    
+    # Draw the rectangle with same rotation as region
+    Wish to draw a rect with center $finalCenter width $w height $h radians $angle color white
+  }
+}
+
+# Simplified syntax for drawing rectangles relative to a region
+When /someone/ wishes /p/ draws a rect with width /w/ height /h/ {
+  When $p has region /r/ {
+    lassign [region centroid $r] cx cy
+    set angle [region angle $r]
+    Wish to draw a rect with center [list $cx $cy] width $w height $h radians $angle color white
+  }
 }
 
 Claim $this has demo {
@@ -94,7 +194,13 @@ Claim $this has demo {
   Wish $this draws a triangle with color green offset {-280 0}
   Wish $this draws a pentagon with color gold offset {-200 0}
   Wish $this draws an octagon with color magenta offset {-250 80}
-
+  
+  # Rectangle examples
+  Wish $this draws a rect with width 150 height 75 color cyan filled true offset {-250 -250}
+  Wish $this draw a rect with width 85 height 110 shifted right 150%
+  Wish $this draw a rect with width 85 height 110 shifted left 100%
+  
+  # Animated circle
   When the clock time is /t/ {
     set offsetVector [list [sin $t] [cos $t]]
     set offsetVector [::vec2::scale $offsetVector 105]


### PR DESCRIPTION
I noticed that `$this` relative shapes had a bug where they adopted the rotation of `$this` but we meant for them to be drawn relative to regions. This lead me down a rabbit hole of noticing a bunch of inconcsitencies with shape drawing so this is a pretty big overhaul of shape drawing but should be backwards compatible while allowing us to easily create new kinds of drawings easily.

![image](https://github.com/user-attachments/assets/f059cf8d-af21-4c64-ba4d-b1e799e0f0fb)
