### PR TITLE
fix esc-pos geom file

### DIFF
--- a/virtual-programs/esc-pos.folk
+++ b/virtual-programs/esc-pos.folk
@@ -49,7 +49,7 @@ namespace eval escpos {
         if {![dict exists $matchDict geometry]} { return }
         set geometry [dict get $matchDict geometry]
         set metaFile [open "$::env(HOME)/folk-printed-programs/$id.meta.folk" w]
-        puts $metaFile [subst -novariables {Claim tag $this has geometry {[read $fd]}}]
+        puts $metaFile [subst {Claim tag \$this has geometry $geometry}]
         close $metaFile
     }
 

--- a/virtual-programs/esc-pos.folk
+++ b/virtual-programs/esc-pos.folk
@@ -49,7 +49,7 @@ namespace eval escpos {
         if {![dict exists $matchDict geometry]} { return }
         set geometry [dict get $matchDict geometry]
         set metaFile [open "$::env(HOME)/folk-printed-programs/$id.meta.folk" w]
-        puts $metaFile [subst {Claim tag \$this has geometry $geometry}]
+        puts $metaFile [subst {Claim tag \$this has geometry {$geometry}}]
         close $metaFile
     }
 


### PR DESCRIPTION
When I dusted my system off, I couldn't print. $fd doesn't exist here.

I'm opening a PR because I'm not sure how we feel about the style here? Should I still try to use `-novariables` instead?