### PR TITLE
Add anchor option to relative text

### DIFF
--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -151,7 +151,8 @@ When /someone/ wishes /p/ draws text /text/ with /...options/ & /p/ has region /
        scale 1.0 \
        layer 0 \
        angle $pageAngle \
-       anchor center
+       anchor center \
+       font "PTSans-Regular"
    ]
 
    set options [dict merge $defaults $options]
@@ -161,13 +162,14 @@ When /someone/ wishes /p/ draws text /text/ with /...options/ & /p/ has region /
    set layer [dict get $options layer]
    set angle [dict get $options angle]
    set anchor [dict get $options anchor]
+   set font [dict get $options font]
 
    set offset [dict_getdef $options offset {0 0}]
    set offset [::process_offset $offset $r]
    set center [vec2 add [list $cx $cy] [vec2 rotate $offset $pageAngle]]
 
    Wish to draw text with position $center scale $scale text $text\
-        color $color radians $angle anchor $anchor
+        color $color radians $angle anchor $anchor font $font
 } 
 
 When /someone/ wishes /p/ draws a /shape/ with /...options/ & /p/ has region /r/ {

--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -151,6 +151,7 @@ When /someone/ wishes /p/ draws text /text/ with /...options/ & /p/ has region /
        scale 1.0 \
        layer 0 \
        angle $pageAngle \
+       anchor center
    ]
 
    set options [dict merge $defaults $options]
@@ -159,12 +160,14 @@ When /someone/ wishes /p/ draws text /text/ with /...options/ & /p/ has region /
    set scale [dict get $options scale]
    set layer [dict get $options layer]
    set angle [dict get $options angle]
+   set anchor [dict get $options anchor]
 
    set offset [dict_getdef $options offset {0 0}]
    set offset [::process_offset $offset $r]
    set center [vec2 add [list $cx $cy] [vec2 rotate $offset $pageAngle]]
 
-   Wish to draw text with position $center scale $scale text $text color $color radians $angle
+   Wish to draw text with position $center scale $scale text $text\
+        color $color radians $angle anchor $anchor
 } 
 
 When /someone/ wishes /p/ draws a /shape/ with /...options/ & /p/ has region /r/ {


### PR DESCRIPTION
Anchor was missing as a parameter into relative text.