### PR TITLE
Improve calibrate autorefresh, expose crop width/height

### DIFF
--- a/virtual-programs/calibrate/calibrate.folk
+++ b/virtual-programs/calibrate/calibrate.folk
@@ -487,22 +487,26 @@ Wish the web server handles route "/calibrate$" with handler [list apply {{UNIT_
               });
 
               function advanceCamera() {
-                cameraFrame.src = cameraFrame.src + '0'
+                cameraFrame.src = '/camera-frame?' + Math.random()
               }
             </script>
 
             <p>Use this camera preview to debug why printed and/or projected tags aren't being recognized (maybe overexposure, maybe your camera isn't in a good position): <button id="refreshButton" onclick="advanceCamera()">Refresh Preview</button> <input type="checkbox" value="true" id="auto-refresh-checkbox" checked>
-  <label for="auto-refresh-checkbox">Automatically refresh preview (May not work well during calibration)</label> </p><br> <img src="/camera-frame?0" id="cameraFrame" style="max-width: 100%"> 
+ <label for="auto-refresh-checkbox">Automatically refresh preview</label> </p><br> <img src="/camera-frame" id="cameraFrame" style="max-width: 100%"> 
 
             <script>
                 const refreshButton = document.getElementById('refreshButton');
                 const autoRefreshCheckbox = document.getElementById('auto-refresh-checkbox');
-                setInterval(() => {
-                     if (autoRefreshCheckbox.checked) {
-                        refreshButton.click()
-                     } 
-                     console.log("checked?", autoRefreshCheckbox.checked)
-                }, 100)
+                cameraFrame.addEventListener('load', () => {
+                  if (autoRefreshCheckbox.checked) {
+                    advanceCamera();
+                  } 
+                });
+                autoRefreshCheckbox.addEventListener('change', () => {
+                  if (autoRefreshCheckbox.checked) {
+                    advanceCamera();
+                  }
+                });
             </script>
 
 

--- a/virtual-programs/camera-usb.folk
+++ b/virtual-programs/camera-usb.folk
@@ -349,7 +349,11 @@ When /someone/ wishes $::thisNode uses camera /cameraPath/ with /...options/ {
         set camera [Camera::new $cameraPath $width $height $bufferCount]
 
         # TODO: report actual width and height from v4l2
-        Claim camera $cameraPath has width $width height $height
+        if {[info exists crop]} {
+            Claim camera $cameraPath has width [dict get $crop width] height [dict get $crop height]
+        } else {
+            Claim camera $cameraPath has width $width height $height
+        }
 
         puts "camera-usb: $cameraPath ($options) (tid [getTid]) booted at [clock milliseconds]"
 


### PR DESCRIPTION
This should greatly reduce how much overhead the calibrate autorefresh imposes, especially on low-end systems. It also should feel more life. It now only refreshes once the previous frame has fully loaded, so not every 100ms (and also fixes problems where you don't see any updates because you're just constantly churning the img)

check that this doesn't break calibrate on other systems?