### PR TITLE
Update README.md user permission commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ if flashing from a Mac] -- Ubuntu doesn't have a good kernel for Pi 5)
    If no `folk` user, then:
 
         sudo useradd -m folk; sudo passwd folk;
+
+   After creating `folk` user, then:
+    
         for group in adm dialout cdrom sudo audio video plugdev games users input tty render netdev lpadmin gpio i2c spi; do sudo usermod -a -G $group folk; done; groups folk
 
 1. `sudo apt update`


### PR DESCRIPTION
Clarify commands that are needed to run to set user sufficient user permissions. Make the user by default run the command to set user permissions.

See #213 