### PR TITLE
Add "draws text" with no arguments

### DIFF
--- a/virtual-programs/shapes.folk
+++ b/virtual-programs/shapes.folk
@@ -173,7 +173,7 @@ When /someone/ wishes /p/ draws text /text/ with /...options/ & /p/ has region /
 } 
 
 When /someone/ wishes /p/ draws text /text/ {
-    Wish $this draws text $text with color white
+    Wish $p draws text $text with color white
 }
 
 When /someone/ wishes /p/ draws a /shape/ with /...options/ & /p/ has region /r/ {


### PR DESCRIPTION
Previously needed to include arguments after "draws text"

`Wish $this draws text Brian; with offset [list 0 0]`

Added draws text capabilities with no argument requirements