### PR TITLE
Fix issue with non-terminated tcl objects

### DIFF
--- a/folk.c
+++ b/folk.c
@@ -94,8 +94,22 @@ Db* db;
 static Clause* jimObjsToClause(int objc, Jim_Obj *const *objv) {
     Clause* clause = malloc(SIZEOF_CLAUSE(objc));
     clause->nTerms = objc;
+
+    char* str;
+    char* newStr;
+    int len;
     for (int i = 0; i < objc; i++) {
-        clause->terms[i] = strdup(Jim_GetString(objv[i], NULL));
+        // Jim "strings" are not guaranteed to be null terminated,
+        // as they're effectively byte arrays. We'll go ahead and
+        // terminate it ourselves in the case that this object is
+        // not terminated.
+        
+        str = Jim_GetString(objv[i], &len);
+        newStr = malloc(len + 1); // +1 for null cap
+        memcpy(newStr, str, len);
+        newStr[len] = 0x00;
+        
+        clause->terms[i] = newStr;
     }
     return clause;
 }

--- a/vendor/jimtcl/jim-base64.c
+++ b/vendor/jimtcl/jim-base64.c
@@ -76,22 +76,18 @@ static const char B64Digits[65] = {
 	outindex++;					\
 	if (maxlen > 0 && cursor != limit) {		\
 	    if (outindex == maxlen) {			\
-		memcpy(cursor, wrapchar, wrapcharlen);	\
-		cursor += wrapcharlen;			\
-		outindex = 0;				\
+			memcpy(cursor, wrapchar, wrapcharlen);	\
+			cursor += wrapcharlen;			\
+			outindex = 0;				\
 	    }						\
 	}						\
 	if (cursor > limit) {				\
 	    Jim_SetResultString(interp, "limit hit", -1);			\
-            return JIM_ERR; \
+        return JIM_ERR; \
 	}						\
     } while (0)
 
-static int
-BinaryEncode64(
-    Jim_Interp *interp,
-    int objc,
-    Jim_Obj *const objv[])
+static int BinaryEncode64(Jim_Interp *interp, int objc, Jim_Obj *const objv[])
 {
     Jim_Obj *resultObj;
     const unsigned char *data, *limit;
@@ -104,95 +100,105 @@ BinaryEncode64(
     static const char *const optStrings[] = { "-maxlen", "-wrapchar", NULL };
 
     if (objc < 2 || objc % 2 != 0) {
-	Jim_WrongNumArgs(interp, 1, objv,
-		"?-maxlen len? ?-wrapchar char? data");
-	return JIM_ERR;
+		Jim_WrongNumArgs(interp, 1, objv, "?-maxlen len? ?-wrapchar char? data");
+		return JIM_ERR;
     }
+
     for (i = 1; i < objc - 1; i += 2) {
-	if (Jim_GetEnum(interp, objv[i], optStrings, &index, "option",
-		0) != JIM_OK) {
-	    return JIM_ERR;
-	}
-	switch (index) {
-	case OPT_MAXLEN:
-	    if (Jim_GetWide(interp, objv[i + 1], &maxlen) != JIM_OK) {
-		return JIM_ERR;
-	    }
-	    if (maxlen < 0) {
-		Jim_SetResult(interp, Jim_NewStringObj(interp,
-			"line length out of range", -1));
-		/* Jim_SetErrorCode(interp, "TCL", "BINARY", "ENCODE", */
-		/* 	"LINE_LENGTH", (char *)NULL); */
-		return JIM_ERR;
-	    }
-	    break;
-	case OPT_WRAPCHAR:
-            // FIXME (osnr): This is weird
-	    wrapchar = (const char *)Jim_GetString(
-		    objv[i + 1], &wrapcharlen);
-	    if (wrapchar == NULL) {
-		purewrap = 0;
-		wrapchar = Jim_GetString(objv[i + 1], &wrapcharlen);
-	    }
-	    break;
-	}
+		if (Jim_GetEnum(interp, objv[i], optStrings, &index, "option", 0) != JIM_OK) {
+			return JIM_ERR;
+		}
+
+		switch (index) {
+			case OPT_MAXLEN:
+				if (Jim_GetWide(interp, objv[i + 1], &maxlen) != JIM_OK) {
+					return JIM_ERR;
+				}
+
+				if (maxlen < 0) {
+					Jim_SetResult(interp, Jim_NewStringObj(interp, "line length out of range", -1));
+					/* Jim_SetErrorCode(interp, "TCL", "BINARY", "ENCODE", */
+					/* 	"LINE_LENGTH", (char *)NULL); */
+					return JIM_ERR;
+				}
+
+				break;
+			case OPT_WRAPCHAR:
+					// FIXME (osnr): This is weird
+				wrapchar = (const char *)Jim_GetString(objv[i + 1], &wrapcharlen);
+
+				if (wrapchar == NULL) {
+					purewrap = 0;
+					wrapchar = Jim_GetString(objv[i + 1], &wrapcharlen);
+				}
+
+				break;
+		}
     }
     if (wrapcharlen == 0) {
-	maxlen = 0;
+		maxlen = 0;
     }
 
     data = (const unsigned char *)Jim_GetString(objv[objc - 1], &count);
     if (data == NULL) {
-	return JIM_ERR;
+		return JIM_ERR;
     }
+
+	if (count == 0) {
+        Jim_SetEmptyResult(interp);
+        return JIM_OK;
+	}
+
     resultObj = Jim_NewObj(interp);
     resultObj->typePtr = NULL;
-    if (count > 0) {
+    
 	unsigned char *cursor = NULL;
 
 	size = (((count * 4) / 3) + 3) & ~3;	/* ensure 4 byte chunks */
 	if (maxlen > 0 && size > maxlen) {
-	    int adjusted = size + (wrapcharlen * (size / maxlen));
+		int adjusted = size + (wrapcharlen * (size / maxlen));
 
-	    if (size % maxlen == 0) {
-		adjusted -= wrapcharlen;
-	    }
-	    size = adjusted;
+		if (size % maxlen == 0) {
+			adjusted -= wrapcharlen;
+		}
+		size = adjusted;
 
-	    if (purewrap == 0) {
-		/* Wrapchar is (possibly) non-byte, so build result as
-		 * general string, not bytearray */
-		resultObj->bytes = Jim_Alloc(size);
-                resultObj->length = size;
-		cursor = (unsigned char *) resultObj->bytes;
-	    }
+		if (purewrap == 0) {
+			/* Wrapchar is (possibly) non-byte, so build result as
+			* general string, not bytearray */
+			resultObj->bytes = Jim_Alloc(size);
+			resultObj->length = size;
+			cursor = (unsigned char *) resultObj->bytes;
+		}
 	}
 	if (cursor == NULL) {
-            resultObj->bytes = Jim_Alloc(size);
-            resultObj->length = size;
-            cursor = (unsigned char *) resultObj->bytes;
+		resultObj->bytes = Jim_Alloc(size);
+		resultObj->length = size;
+		cursor = (unsigned char *) resultObj->bytes;
 	}
 	limit = cursor + size;
 	for (offset = 0; offset < count; offset += 3) {
-	    unsigned char d[3] = {0, 0, 0};
+		unsigned char d[3] = {0, 0, 0};
 
-	    for (i = 0; i < 3 && offset + i < count; ++i) {
-		d[i] = data[offset + i];
-	    }
-	    OUTPUT(B64Digits[d[0] >> 2]);
-	    OUTPUT(B64Digits[((d[0] & 0x03) << 4) | (d[1] >> 4)]);
-	    if (offset + 1 < count) {
-		OUTPUT(B64Digits[((d[1] & 0x0F) << 2) | (d[2] >> 6)]);
-	    } else {
-		OUTPUT(B64Digits[64]);
-	    }
-	    if (offset+2 < count) {
-		OUTPUT(B64Digits[d[2] & 0x3F]);
-	    } else {
-		OUTPUT(B64Digits[64]);
-	    }
+		for (i = 0; i < 3 && offset + i < count; ++i) {
+			d[i] = data[offset + i];
+		}
+		OUTPUT(B64Digits[d[0] >> 2]);
+		OUTPUT(B64Digits[((d[0] & 0x03) << 4) | (d[1] >> 4)]);
+
+		if (offset + 1 < count) {
+			OUTPUT(B64Digits[((d[1] & 0x0F) << 2) | (d[2] >> 6)]);
+		} else {
+			OUTPUT(B64Digits[64]);
+		}
+
+		if (offset + 2 < count) {
+			OUTPUT(B64Digits[d[2] & 0x3F]);
+		} else {
+			OUTPUT(B64Digits[64]);
+		}
 	}
-    }
+
     Jim_SetResult(interp, resultObj);
     return JIM_OK;
 }
@@ -215,11 +221,7 @@ BinaryEncode64(
  *----------------------------------------------------------------------
  */
 
-static int
-BinaryDecode64(
-    Jim_Interp *interp,
-    int objc,
-    Jim_Obj *const objv[])
+static int BinaryDecode64(Jim_Interp *interp, int objc, Jim_Obj *const objv[])
 {
     Jim_Obj *resultObj = NULL;
     unsigned char *data, *datastart, *dataend, c = '\0';
@@ -233,19 +235,20 @@ BinaryDecode64(
     static const char *const optStrings[] = { "-strict", NULL };
 
     if (objc < 2 || objc > 3) {
-	Jim_WrongNumArgs(interp, 1, objv, "?options? data");
-	return JIM_ERR;
+		Jim_WrongNumArgs(interp, 1, objv, "?options? data");
+		return JIM_ERR;
     }
+
     for (i = 1; i < objc - 1; ++i) {
-	if (Jim_GetEnum(interp, objv[i], optStrings, &index, "option",
-		0) != JIM_OK) {
-	    return JIM_ERR;
-	}
-	switch (index) {
-	case OPT_STRICT:
-	    strict = 1;
-	    break;
-	}
+		if (Jim_GetEnum(interp, objv[i], optStrings, &index, "option", 0) != JIM_OK) {
+			return JIM_ERR;
+		}
+
+		switch (index) {
+			case OPT_STRICT:
+				strict = 1;
+				break;
+		}
     }
 
     resultObj = Jim_NewObj(interp);
@@ -264,97 +267,99 @@ BinaryDecode64(
     resultObj->bytes = Jim_Alloc(size);
     resultObj->length = size;
     begin = cursor = (unsigned char *)resultObj->bytes;
+
     while (data < dataend) {
-	unsigned long value = 0;
+		unsigned long value = 0;
 
-	/*
-	 * Decode the current block. Each base64 block consists of four input
-	 * characters A-Z, a-z, 0-9, +, or /. Each character supplies six bits
-	 * of output data, so each block's output is 24 bits (three bytes) in
-	 * length. The final block can be shorter by one or two bytes, denoted
-	 * by the input ending with one or two ='s, respectively.
-	 */
-
-	for (i = 0; i < 4; i++) {
-	    /*
-	     * Get the next input character. At end of input, pad with at most
-	     * two ='s. If more than two ='s would be needed, instead discard
-	     * the block read thus far.
-	     */
-
-	    if (data < dataend) {
-		c = *data++;
-	    } else if (i > 1) {
-		c = '=';
-	    } else {
-		if (strict && i <= 1) {
-		    /*
-		     * Single resp. unfulfilled char (each 4th next single
-		     * char) is rather bad64 error case in strict mode.
-		     */
-
-		    goto bad64;
-		}
-		cut += 3;
-		break;
-	    }
-
-	    /*
-	     * Load the character into the block value. Handle ='s specially
-	     * because they're only valid as the last character or two of the
-	     * final block of input. Unless strict mode is enabled, skip any
-	     * input whitespace characters.
-	     */
-
-	    if (cut) {
-		if (c == '=' && i > 1) {
-		    value <<= 6;
-		    cut++;
-		} else if (!strict) {
-		    i--;
-		} else {
-		    goto bad64;
-		}
-	    } else if (c >= 'A' && c <= 'Z') {
-		value = (value << 6) | ((c - 'A') & 0x3F);
-	    } else if (c >= 'a' && c <= 'z') {
-		value = (value << 6) | ((c - 'a' + 26) & 0x3F);
-	    } else if (c >= '0' && c <= '9') {
-		value = (value << 6) | ((c - '0' + 52) & 0x3F);
-	    } else if (c == '+') {
-		value = (value << 6) | 0x3E;
-	    } else if (c == '/') {
-		value = (value << 6) | 0x3F;
-	    } else if (c == '=' && (!strict || i > 1)) {
 		/*
-		 * "=" and "a=" is rather bad64 error case in strict mode.
-		 */
+		* Decode the current block. Each base64 block consists of four input
+		* characters A-Z, a-z, 0-9, +, or /. Each character supplies six bits
+		* of output data, so each block's output is 24 bits (three bytes) in
+		* length. The final block can be shorter by one or two bytes, denoted
+		* by the input ending with one or two ='s, respectively.
+		*/
 
-		value <<= 6;
-		if (i) {
-		    cut++;
+		for (i = 0; i < 4; i++) {
+			/*
+			* Get the next input character. At end of input, pad with at most
+			* two ='s. If more than two ='s would be needed, instead discard
+			* the block read thus far.
+			*/
+
+			if (data < dataend) {
+				c = *data++;
+			} else if (i > 1) {
+				c = '=';
+			} else {
+				if (strict && i <= 1) {
+					/*
+					* Single resp. unfulfilled char (each 4th next single
+					* char) is rather bad64 error case in strict mode.
+					*/
+
+					goto bad64;
+				}
+				cut += 3;
+				break;
+			}
+
+			/*
+			* Load the character into the block value. Handle ='s specially
+			* because they're only valid as the last character or two of the
+			* final block of input. Unless strict mode is enabled, skip any
+			* input whitespace characters.
+			*/
+
+			if (cut) {
+				if (c == '=' && i > 1) {
+					value <<= 6;
+					cut++;
+				} else if (!strict) {
+					i--;
+				} else {
+					goto bad64;
+				}
+			} else if (c >= 'A' && c <= 'Z') {
+				value = (value << 6) | ((c - 'A') & 0x3F);
+			} else if (c >= 'a' && c <= 'z') {
+				value = (value << 6) | ((c - 'a' + 26) & 0x3F);
+			} else if (c >= '0' && c <= '9') {
+				value = (value << 6) | ((c - '0' + 52) & 0x3F);
+			} else if (c == '+') {
+				value = (value << 6) | 0x3E;
+			} else if (c == '/') {
+				value = (value << 6) | 0x3F;
+			} else if (c == '=' && (!strict || i > 1)) {
+				/*
+				* "=" and "a=" is rather bad64 error case in strict mode.
+				*/
+
+				value <<= 6;
+				if (i) {
+					cut++;
+				}
+			} else if (strict) {
+				goto bad64;
+			} else {
+				i--;
+			}
 		}
-	    } else if (strict) {
-		goto bad64;
-	    } else {
-		i--;
-	    }
-	}
-	*cursor++ = UCHAR((value >> 16) & 0xFF);
-	*cursor++ = UCHAR((value >> 8) & 0xFF);
-	*cursor++ = UCHAR(value & 0xFF);
 
-	/*
-	 * Since = is only valid within the final block, if it was encountered
-	 * but there are still more input characters, confirm that strict mode
-	 * is off and all subsequent characters are whitespace.
-	 */
+		*cursor++ = UCHAR((value >> 16) & 0xFF);
+		*cursor++ = UCHAR((value >> 8) & 0xFF);
+		*cursor++ = UCHAR(value & 0xFF);
 
-	if (cut && data < dataend) {
-	    if (strict) {
-		goto bad64;
-	    }
-	}
+		/*
+		* Since = is only valid within the final block, if it was encountered
+		* but there are still more input characters, confirm that strict mode
+		* is off and all subsequent characters are whitespace.
+		*/
+
+		if (cut && data < dataend) {
+			if (strict) {
+				goto bad64;
+			}
+		}
     }
     resultObj->length = cursor - begin - cut;
     // Jim_SetByteArrayLength(resultObj, cursor - begin - cut);


### PR DESCRIPTION
Tcl doesn't guarantee that objects are null-terminated, as they're effectively byte arrays. This tags on a terminator when copying objects into a clause.