### PR TITLE
Rewrite Unix command runner to use bounded streaming

### DIFF
--- a/virtual-programs/unix-commands.folk
+++ b/virtual-programs/unix-commands.folk
@@ -93,8 +93,8 @@ When /someone/ wishes /p/ runs Unix command /command/ with arguments /args/ {
 }
 
 # Convenience wrapper for commands without arguments
-When /someone/ wishes /p/ runs Unix command /command/ {
-	Say $someone wishes $p runs Unix command $command with arguments [list]
+When /wisher/ wishes /p/ runs Unix command /command/ {
+	Say $wisher wishes $p runs Unix command $command with arguments [list]
 }
 
 # When /someone/ wishes /p/ tests Unix commands {

--- a/virtual-programs/unix-commands.folk
+++ b/virtual-programs/unix-commands.folk
@@ -1,33 +1,124 @@
-set ::unixjobs [dict create]
-set ::nextunixjobid 0
+# Spawns a Unix command to stream output lines back to the Wisher.
+#
+# Wish $p runs Unix command "echo" with arguments [list "Hello" "World"]
+# Wish $this runs Unix command "journalctl" with arguments [list "-f" "-u" "folk"]
+When /someone/ wishes /p/ runs Unix command /command/ with arguments /args/ {
+	set outputKeyName [list unix-output $p]
+	set errorKeyName [list unix-error $p]
+	set maxLines 500
+	set maxLinesEndIndex [expr {$maxLines - 1}]
+	set accumulatedLines [list]
 
-proc ::readline {jobid channel} {
-	if {[gets $channel line] >= 0} {
-		dict with ::unixjobs $jobid {
-			lappend log $line
-			Retract $object is running Unix command $command with job id $jobid output /something/
-			Assert $object is running Unix command $command with job id $jobid output $log
-			Step
+	# Bound how many lines we drain per tick to avoid starvation under heavy output
+	set maxLinesPerTick 10
+
+	# Build argv as a flat list and form pipeline tokens
+	set flatArgs [concat {*}$args]
+	set argv [list $command {*}$flatArgs]
+	set pipeline [linsert $argv 0 |]
+
+	try {
+		# Start the process with STDERR merged into STDOUT
+		lappend pipeline 2>@1
+		set fd [open $pipeline r]
+
+		fconfigure $fd -blocking 0 -buffering none
+
+		set pids [pid $fd]
+		set pid [lindex $pids end]
+	} on error e {
+		puts "Failed to open '$command': $e"
+
+		Hold! -key $errorKeyName \
+			Claim $p has Unix error output $e
+
+		return
+	}
+
+	On unmatch [list apply {{fd pid} {
+		catch {close $fd}
+		catch {kill SIGTERM $pid}
+		after 500
+		catch {kill SIGKILL $pid}
+	} } $fd $pid]
+
+	while true {
+		set newLines [list]
+		set drained 0
+
+		while {$drained < $maxLinesPerTick} {
+			set num [gets $fd line]
+			if {$num < 0} { break }
+
+			lappend newLines $line
+			incr drained
 		}
-	} elseif {[eof $channel]} {
-		close $channel
+
+		if {[llength $newLines] > 0} {
+			set accumulatedLines [concat $accumulatedLines $newLines]
+			set length [llength $accumulatedLines]
+
+			if {$length > $maxLines} {
+				set accumulatedLines [lrange $accumulatedLines end-$maxLinesEndIndex end]
+			}
+
+			Hold! -key $outputKeyName \
+				Claim $p has Unix output lines $accumulatedLines
+		}
+
+		if {[eof $fd]} {
+			# Emit any last partial unterminated lines
+			set tail [read $fd]
+
+			if {$tail ne ""} {
+				set accumulatedLines [concat $accumulatedLines [list $tail]]
+
+				Hold! -key $outputKeyName \
+					Claim $p has Unix output lines $accumulatedLines
+			}
+
+			if {[catch {close $fd} err]} {
+				puts "Close error for '$command': $err"
+
+				Hold! -key $errorKeyName \
+					Claim $p has Unix error output $err
+			}
+
+			break
+		}
+
+		# Sleep for a bit to avoid starving under heavy output
+		after 100
 	}
 }
 
-When /someone/ wishes /p/ runs Unix command /c/ {
-	set jobid [incr ::nextunixjobid]
-	dict set ::unixjobs $jobid [dict create object $p command $c log [list]]
-
-	lassign [socket pipe] reader writer
-	set pid [exec {*}$c >@$writer 2>@1 &]
-	close $writer
-
-	fconfigure $reader -blocking 0
-	fileevent $reader readable [list ::readline $jobid $reader]
-
-	When /p/ is running Unix command /c/ with job id $jobid output /log/ {
-		Wish $p is labelled [join $log "\n"]
-	}
-
-	On unmatch [list exec kill $pid]
+# Convenience wrapper for commands without arguments
+When /someone/ wishes /p/ runs Unix command /command/ {
+	Say $someone wishes $p runs Unix command $command with arguments [list]
 }
+
+# When /someone/ wishes /p/ tests Unix commands {
+# 	# Wish $p runs Unix command "echo" with arguments [list "Hello" "World"]
+# 	# Wish $p runs Unix command "curl" with arguments [list "-fsS" "http://wttr.in/Baltimore?format='%l:+%C'"]
+# 	# Wish $p runs Unix command "ls" with arguments [list "-sSh" "/home/folk/folk2"]
+# 	# Wish $p runs Unix command "ping" with arguments [list "google.com"]
+# 	# Wish $p runs Unix command "sh" with arguments [list "-c" "while :; do date +%s.%3N; sleep 0.5; done"]
+
+# 	# Test error handling:
+# 	# Wish $p runs Unix command "ls" with arguments [list "/nonexistent/path"]
+# 	# Wish $p runs Unix command "exec" with arguments [list "/dev/null"]
+
+# 	When $p has Unix error output /errorSummary/ {
+# 		puts "errorSummary: $errorSummary"
+
+# 		Wish $p is labelled [join $errorSummary "\n"]
+# 		Wish $p is outlined red
+# 	}
+
+# 	When $p has Unix output lines /outputLines/ {
+# 		puts "outputLines: $outputLines"
+
+# 		Wish $p is labelled [join $outputLines "\n"]
+# 		Wish $p is outlined green
+# 	}
+# }


### PR DESCRIPTION
This change replaces global, stateful job management of Unix command invocations with scoped, declarative claims.

- Keeps at most 500 lines and drops the oldest when exceeded
- Drains at most 10 lines per tick; waits `after 100` between ticks to prevent starvation
- Emits any final unterminated string on `EOF`
- Rescues I/O errors and emits as `Claim` statements

NOTE: I tried several approaches using `exec`, `fileevent`, etc, but `open |` gave the best overall performance. I'm definitely open to changing anything if there's a more Folk-idiomatic way of handling this kind of I/O.