### PR TITLE
calibrate: Add tangential distortion (p1, p2) to calibration model

### DIFF
--- a/builtin-programs/calibrate/calibrate.folk
+++ b/builtin-programs/calibrate/calibrate.folk
@@ -808,7 +808,7 @@ fn zhangUnrefinedCalibrate {name width height Hs} {
     set intrinsics [dict create \
                         width $width height $height \
                         fx $fx fy $fy cx $cx cy $cy s $s \
-                        k1 0 k2 0]
+                        k1 0 k2 0 p1 0 p2 0]
     return [dict create \
                 name $name \
                 intrinsics $intrinsics \

--- a/builtin-programs/calibrate/load-calibration.folk
+++ b/builtin-programs/calibrate/load-calibration.folk
@@ -22,14 +22,14 @@ When the calibration is /nothing/ {
             width $displayWidth height $displayHeight \
             fx $displayWidth fy $displayWidth \
             cx [/ $displayWidth 2.0] cy [/ $displayHeight 2.0] \
-            s 0 k1 0 k2 0]
+            s 0 k1 0 k2 0 p1 0 p2 0]
     }
     When camera /cam/ has width /cameraWidth/ height /cameraHeight/ {
         Claim camera $cam has intrinsics [dict create \
             width $cameraWidth height $cameraHeight \
             fx $cameraWidth fy $cameraWidth \
             cx [/ $cameraWidth 2.0] cy [/ $cameraHeight 2.0] \
-            s 0 k1 0 k2 0]
+            s 0 k1 0 k2 0 p1 0 p2 0]
     }
     When display /disp/ has width /any/ height /any/ &\
          camera /cam/ has width /any/ height /any/ {
@@ -43,6 +43,17 @@ When the calibration is /calibration/ {
     puts "\n\n====NEW CALIBRATION ([string range $calibration 0 100])=====\n\n"
     set camera [dict get $calibration camera name]
     set display [dict get $calibration projector name]
+
+    # Backfill p1/p2 for calibrations saved before tangential
+    # distortion support was added.
+    foreach device {camera projector} {
+        foreach key {p1 p2} {
+            if {![dict exists $calibration $device intrinsics $key]} {
+                dict set calibration $device intrinsics $key 0
+            }
+        }
+    }
+
     Claim camera $camera has intrinsics \
         [dict get $calibration camera intrinsics]
     Claim display $display has intrinsics \

--- a/builtin-programs/calibrate/refine.folk
+++ b/builtin-programs/calibrate/refine.folk
@@ -86,6 +86,8 @@ $cc code [csubst {
         double cy;
         double k1;
         double k2;
+        double p1;
+        double p2;
 
         // Makes it easy to project. Same information as fx,
         // cx, fy, cy.
@@ -107,6 +109,8 @@ $cc code [csubst {
 
         intr->k1 = x[k++];
         intr->k2 = x[k++];
+        intr->p1 = x[k++];
+        intr->p2 = x[k++];
         return k;
     }
 
@@ -201,12 +205,16 @@ $cc code {
     }
     void undistort(Intrinsics intr,
                    double xy[2], double out[2]) {
-        double x = (xy[0] - intr.cx)/intr.fx;
-        double y = (xy[1] - intr.cy)/intr.fy;
-        for (int i = 0; i < 3; i++) {
+        double x0 = (xy[0] - intr.cx)/intr.fx;
+        double y0 = (xy[1] - intr.cy)/intr.fy;
+        double x = x0, y = y0;
+        for (int i = 0; i < 5; i++) {
             double r2 = x*x + y*y;
-            double rad = 1.0 + intr.k1 * r2 + intr.k2 * r2*r2;
-            x /= rad; y /= rad;
+            double radial = 1.0 + intr.k1 * r2 + intr.k2 * r2*r2;
+            double dx = 2*intr.p1*x*y + intr.p2*(r2 + 2*x*x);
+            double dy = intr.p1*(r2 + 2*y*y) + 2*intr.p2*x*y;
+            x = (x0 - dx) / radial;
+            y = (y0 - dy) / radial;
         }
         out[0] = x*intr.fx + intr.cx; out[1] = y*intr.fy + intr.cy;
     }
@@ -215,9 +223,11 @@ $cc code {
         double x = (xy[0] - intr.cx)/intr.fx;
         double y = (xy[1] - intr.cy)/intr.fy;
         double r2 = x*x + y*y;
-        double D = intr.k1 * r2 + intr.k2 * r2*r2;
-        out[0] = (x * (1.0 + D))*intr.fx + intr.cx;
-        out[1] = (y * (1.0 + D))*intr.fy + intr.cy;
+        double radial = intr.k1 * r2 + intr.k2 * r2*r2;
+        double dx = 2*intr.p1*x*y + intr.p2*(r2 + 2*x*x);
+        double dy = intr.p1*(r2 + 2*y*y) + 2*intr.p2*x*y;
+        out[0] = (x * (1.0 + radial) + dx)*intr.fx + intr.cx;
+        out[1] = (y * (1.0 + radial) + dy)*intr.fy + intr.cy;
     }
 
     double dist(double a[2], double b[2]) {
@@ -291,7 +301,7 @@ $cc proc monoRefineCalibrationOptimize {double[] params int paramsCount} Jim_Obj
 
     mp_result result = {0};
 
-    assert(paramsCount == 6 + MonoPoseCount*6);
+    assert(paramsCount == 8 + MonoPoseCount*6);
     printf("Unrefined -----------------\n");
     monoComputeError(params, paramsCount);
 
@@ -503,7 +513,7 @@ fn refineMonoCalibration {calibration} {
     $refineLib monoSetPoints [llength [dict get $calibration poses]] \
         $posePointsCount $poseModelPoints $posePoints
 
-    set intrNames {fx cx fy cy k1 k2}
+    set intrNames {fx cx fy cy k1 k2 p1 p2}
 
     # Load the initial guesses for all parameters for fitting.
     set params [lmap intrName $intrNames {
@@ -677,7 +687,7 @@ fn refineCalibration {isPrintedTag isProjectedTag matLib
         [concat {*}$poseCameraPoints] \
         [concat {*}$poseProjectorPoints]
 
-    set intrNames {fx cx fy cy k1 k2}
+    set intrNames {fx cx fy cy k1 k2 p1 p2}
     $refineLib stereoSetIntrinsics [lmap intrName $intrNames {
         dict get $calibration camera intrinsics $intrName
     }] [lmap intrName $intrNames {

--- a/builtin-programs/tags-to-quads.folk
+++ b/builtin-programs/tags-to-quads.folk
@@ -22,18 +22,23 @@ $cc struct Intrinsics {
 
     double k1;
     double k2;
+
+    double p1;
+    double p2;
 }
 
 # Intrinsics helpers:
 $cc proc distort {double fx double fy double cx double cy
-                  double k1 double k2
+                  double k1 double k2 double p1 double p2
                   double xy[2] double out[2]} void {
     double x = (xy[0] - cx)/fx;
     double y = (xy[1] - cy)/fy;
     double r2 = x*x + y*y;
-    double D = k1 * r2 + k2 * r2*r2;
-    out[0] = (x * (1.0 + D))*fx + cx;
-    out[1] = (y * (1.0 + D))*fy + cy;
+    double radial = k1 * r2 + k2 * r2*r2;
+    double dx = 2*p1*x*y + p2*(r2 + 2*x*x);
+    double dy = p1*(r2 + 2*y*y) + 2*p2*x*y;
+    out[0] = (x * (1.0 + radial) + dx)*fx + cx;
+    out[1] = (y * (1.0 + radial) + dy)*fy + cy;
 }
 $cc proc project {Intrinsics intr double width double height
                   double[3] v} Jim_Obj* {
@@ -44,7 +49,7 @@ $cc proc project {Intrinsics intr double width double height
     };
     out[0] /= out[2]; out[1] /= out[2];
     distort(intr.fx, intr.fy, intr.cx, intr.cy,
-            intr.k1, intr.k2,
+            intr.k1, intr.k2, intr.p1, intr.p2,
             out, out);
     out[0] *= width / intr.width;
     out[1] *= height / intr.height;
@@ -61,12 +66,16 @@ $cc proc rescaleAndUndistort {Intrinsics intr
     double x = in[0] * intr.width / cameraWidth;
     double y = in[1] * intr.height / cameraHeight;
 
-    x = (x - intr.cx) / intr.fx;
-    y = (y - intr.cy) / intr.fy;
-    for (int i = 0; i < 3; i++) {
+    double x0 = (x - intr.cx) / intr.fx;
+    double y0 = (y - intr.cy) / intr.fy;
+    x = x0; y = y0;
+    for (int i = 0; i < 5; i++) {
         double r2 = x*x + y*y;
-        double rad = 1.0 + intr.k1 * r2 + intr.k2 * r2*r2;
-        x /= rad; y /= rad;
+        double radial = 1.0 + intr.k1 * r2 + intr.k2 * r2*r2;
+        double dx = 2*intr.p1*x*y + intr.p2*(r2 + 2*x*x);
+        double dy = intr.p1*(r2 + 2*y*y) + 2*intr.p2*x*y;
+        x = (x0 - dx) / radial;
+        y = (y0 - dy) / radial;
     }
     out[0] = x*intr.fx + intr.cx;
     out[1] = y*intr.fy + intr.cy;


### PR DESCRIPTION
I was getting really bad calibrations with [this ELP camera + 5-50mm lens](https://de.aliexpress.com/item/32957328221.html?spm=a2g0o.order_list.order_list_main.5.69115c5fw4pfoY&gatewayAdapt=glo2deu). I tried calibrating 5-10 times. I got OK RMSE scores, but manual testing revealed a significant translation error of 5-10 cm towards the bottom-left every time.

The lens on this camera creates very significant lens distortion at the edges compared to a normal webcam. From looking at photos it appears to be radial distortion which folk should handle as is. However, I verified that folk's distortion model wasn't capturing it by exporting the raw calibration pose data from Folk and running cv2.calibrateCamera on them to check for improvements.

Example picture from the ELP camera. My table has straight sides and you can clearly see how much it appears to curve in the photo.

![pose-1775486867657-5](https://github.com/user-attachments/assets/2da0f317-30fa-4cee-9cab-131c2542089a)


## Claude's auto-generated summary

   - Adds tangential distortion parameters `p1` and `p2` to the camera/projector intrinsics model
   - Extends the distortion model from purely radial (`k1*r² + k2*r⁴`) to include tangential terms per the standard OpenCV 5-parameter model
   - Updates distort/undistort in both the runtime projection pipeline (`tags-to-quads.folk`) and the calibration optimizer (`refine.folk`)
   - Initializes `p1=0, p2=0` in Zhang's calibration and fallback intrinsics
   - Backfills `p1=0, p2=0` in `load-calibration.folk` for old calibrations saved without these keys

   Cameras or projectors with significant lens distortion (e.g. wide-angle cameras, short-throw projectors with lens shift) can exhibit tangential distortion that radial terms alone cannot capture. Testing with OpenCV on calibration data from a setup with heavy lens distortion showed adding `p1`, `p2` reduces reprojection RMSE by ~40%.

   Even when p1/p2 are zero at runtime, having them available during calibration fitting prevents the optimizer from biasing the other parameters (fx, fy, cx, cy, k1, k2) to compensate for unmodeled distortion.

   **Note on k3:** OpenCV's full 5-parameter model also includes `k3` (a `r⁶` radial term). We tested this independently and it provided negligible improvement (~0.3% RMSE change), while p1/p2 provided ~40% improvement. k3 is omitted to keep the model minimal, but could be added later if needed for other setups.

   ## Test plan

   - [ ] `make` builds cleanly
   - [ ] Backwards compatibility: Old calibrations without p1/p2 load correctly (backfill defaults to 0)
   - [ ] Delete existing calibration, restart, recalibrate from scratch
   - [ ] Check that camera and projector RMSE values are reasonable
   - [ ] Verify runtime projection alignment

   🤖 Generated with [Claude Code](https://claude.com/claude-code)