### PR TITLE
FIx transparency in drawing programs

### DIFF
--- a/builtin-programs/draw/circle.folk
+++ b/builtin-programs/draw/circle.folk
@@ -20,9 +20,17 @@ Wish the GPU compiles pipeline "circle" {
 
         float dist = length(surfaceXy.xy - center) - radius;
         if (filled == 1) {
-            return (dist < thickness) ? color : vec4(0, 0, 0, 0);
+            if (dist < thickness) {
+                return color;
+            } else {
+                discard;
+            }
         } else {
-            return (dist < thickness && dist > 0.0) ? color : vec4(0, 0, 0, 0);
+            if (dist < thickness && dist > 0.0) {
+                return color;
+            } else {
+                discard;
+            }
         }
     }
 }

--- a/builtin-programs/draw/circle.folk
+++ b/builtin-programs/draw/circle.folk
@@ -20,17 +20,9 @@ Wish the GPU compiles pipeline "circle" {
 
         float dist = length(surfaceXy.xy - center) - radius;
         if (filled == 1) {
-            if (dist < thickness) {
-                return color;
-            } else {
-                discard;
-            }
+            return (dist < thickness) ? color : vec4(0.0);
         } else {
-            if (dist < thickness && dist > 0.0) {
-                return color;
-            } else {
-                discard;
-            }
+            return (dist < thickness && dist > 0.0) ? color : vec4(0.0);
         }
     }
 }

--- a/builtin-programs/draw/dashed-line.folk
+++ b/builtin-programs/draw/dashed-line.folk
@@ -32,7 +32,11 @@ Wish the GPU compiles pipeline "dashed-line" {
         q = abs(q) - vec2(l, thickness)*0.5;
         float dist = length(max(q, 0.0)) + min(max(q.x, q.y), 0.0);
 
-        return (dist < 0.0 && floor(mod(t / dashlength, 2)) == 0) ? color : vec4(0, 0, 0, 0);
+        if (dist < 0.0 && floor(mod(t / dashlength, 2.0)) == 0.0) {
+            return color;
+        } else {
+            discard;
+        }
     }
 }
 

--- a/builtin-programs/draw/dashed-line.folk
+++ b/builtin-programs/draw/dashed-line.folk
@@ -32,11 +32,7 @@ Wish the GPU compiles pipeline "dashed-line" {
         q = abs(q) - vec2(l, thickness)*0.5;
         float dist = length(max(q, 0.0)) + min(max(q.x, q.y), 0.0);
 
-        if (dist < 0.0 && floor(mod(t / dashlength, 2.0)) == 0.0) {
-            return color;
-        } else {
-            discard;
-        }
+        return (dist < 0.0 && floor(mod(t / dashlength, 2.0)) == 0.0) ? color : vec4(0.0);
     }
 }
 

--- a/builtin-programs/draw/image.folk
+++ b/builtin-programs/draw/image.folk
@@ -85,13 +85,14 @@ Wish the GPU compiles pipeline "image" {
         vec2 uv = invBilinear(surfaceXy.xy, a, b, c, d);
         if( max( abs(uv.x-0.5), abs(uv.y-0.5))<0.5 ) {
             vec4 texColor = texture(image, uv);
-            // Discard fully transparent pixels from the image file itself (e.g., in PNGs/GIFs)
-            if (texColor.a < 0.01) {
-                discard;
+
+            if ((texColor.a < 0.01) || (texColor.r < 0.05 && texColor.g < 0.05 && texColor.b < 0.05)) {
+                return vec4(0.0);
             }
+
             return texColor;
         }
-        discard;
+        return vec4(0.0);
 }}
 When the image library is /imageLib/ &\
      /someone/ wishes to draw an image onto /p/ with /...options/ &\

--- a/builtin-programs/draw/image.folk
+++ b/builtin-programs/draw/image.folk
@@ -84,9 +84,14 @@ Wish the GPU compiles pipeline "image" {
 
         vec2 uv = invBilinear(surfaceXy.xy, a, b, c, d);
         if( max( abs(uv.x-0.5), abs(uv.y-0.5))<0.5 ) {
-            return texture(image, uv);
+            vec4 texColor = texture(image, uv);
+            // Discard fully transparent pixels from the image file itself (e.g., in PNGs/GIFs)
+            if (texColor.a < 0.01) {
+                discard;
+            }
+            return texColor;
         }
-        return vec4(0.0, 0.0, 0.0, 0.0);
+        discard;
 }}
 When the image library is /imageLib/ &\
      /someone/ wishes to draw an image onto /p/ with /...options/ &\
@@ -177,4 +182,3 @@ When the image library is /imageLib/ &\
 When /someone/ wishes /p/ displays image /im/ {
     Wish $p displays image $im with scale 1.0
 }
-

--- a/builtin-programs/draw/line.folk
+++ b/builtin-programs/draw/line.folk
@@ -27,7 +27,11 @@ Wish the GPU compiles pipeline "line" {
         q = abs(q) - vec2(l, thickness)*0.5;
         float dist = length(max(q, 0.0)) + min(max(q.x, q.y), 0.0);
 
-        return dist < 0.0 ? color : vec4(0.0, 0.0, 0.0, 0.0);
+        if (dist < 0.0) {
+            return color;
+        } else {
+            discard;
+        }
     }
 }
 

--- a/builtin-programs/draw/line.folk
+++ b/builtin-programs/draw/line.folk
@@ -27,11 +27,7 @@ Wish the GPU compiles pipeline "line" {
         q = abs(q) - vec2(l, thickness)*0.5;
         float dist = length(max(q, 0.0)) + min(max(q.x, q.y), 0.0);
 
-        if (dist < 0.0) {
-            return color;
-        } else {
-            discard;
-        }
+        return (dist < 0.0) ? color : vec4(0.0);
     }
 }
 

--- a/builtin-programs/draw/text.folk
+++ b/builtin-programs/draw/text.folk
@@ -253,7 +253,7 @@ Wish the GPU compiles pipeline "glyph" {
 
     vec2 glyphUv = invBilinear(surfaceXy.xy, a, b, c, d);
     if( max( abs(glyphUv.x-0.5), abs(glyphUv.y-0.5))>=0.5 ) {
-        return vec4(0, 0, 0, 0);
+        discard;
     }
     vec3 msd = glyphMsd(atlas, atlasGlyphBounds, glyphUv).rgb;
     // https://blog.mapbox.com/drawing-text-with-signed-distance-fields-in-mapbox-gl-b0933af6f817
@@ -261,6 +261,9 @@ Wish the GPU compiles pipeline "glyph" {
     float uBuffer = 0.2;
     float uGamma = 0.2;
     float opacity = smoothstep(uBuffer - uGamma, uBuffer + uGamma, sd);
+    if (opacity < 0.01) {
+        discard;
+    }
     return vec4(color.rgb, opacity * color.a);
 }}
 

--- a/builtin-programs/draw/text.folk
+++ b/builtin-programs/draw/text.folk
@@ -253,7 +253,7 @@ Wish the GPU compiles pipeline "glyph" {
 
     vec2 glyphUv = invBilinear(surfaceXy.xy, a, b, c, d);
     if( max( abs(glyphUv.x-0.5), abs(glyphUv.y-0.5))>=0.5 ) {
-        discard;
+        return vec4(0.0);
     }
     vec3 msd = glyphMsd(atlas, atlasGlyphBounds, glyphUv).rgb;
     // https://blog.mapbox.com/drawing-text-with-signed-distance-fields-in-mapbox-gl-b0933af6f817
@@ -261,10 +261,8 @@ Wish the GPU compiles pipeline "glyph" {
     float uBuffer = 0.2;
     float uGamma = 0.2;
     float opacity = smoothstep(uBuffer - uGamma, uBuffer + uGamma, sd);
-    if (opacity < 0.01) {
-        discard;
-    }
-    return vec4(color.rgb, opacity * color.a);
+
+    return (opacity < 0.01) ? vec4(0.0) : vec4(color.rgb, opacity * color.a);
 }}
 
 When the color map is /colorMap/ &\

--- a/builtin-programs/gpu/canvases.folk
+++ b/builtin-programs/gpu/canvases.folk
@@ -456,6 +456,32 @@ When the GPU library is /gpuLib/ & the GPU draw library is /drawLib/ &\
         }
     }
 
+    Wish the GPU compiles pipeline "composite-canvas" {
+        {vec2 viewport mat3 surfaceToClip
+            sampler2D image vec2 a vec2 b vec2 c vec2 d} {
+            vec2 vertices[6] = vec2[6](a, b, c, a, c, d);
+            vec3 v = surfaceToClip * vec3(vertices[gl_VertexIndex], 1.0);
+            return vec4(v.xy/v.z, 0.0, 1.0);
+
+        } {fn invBilinear} {
+            vec2 clipXy = (gl_FragCoord.xy / viewport) * 2.0 - 1.0;
+            vec3 surfaceXy = inverse(surfaceToClip) * vec3(clipXy, 1.0);
+            surfaceXy /= surfaceXy.z;
+
+            vec2 uv = invBilinear(surfaceXy.xy, a, b, c, d);
+            if( max( abs(uv.x-0.5), abs(uv.y-0.5))<0.5 ) {
+                vec4 texColor = texture(image, uv);
+                
+                // Prevent divide-by-zero errors on empty pixels
+                if (texColor.a < 0.001) return vec4(0.0);
+                
+                // Un-premultiply! The compiler's auto-premultiply will cancel this out, 
+                // leaving the canvas pixels mathematically untouched.
+                return vec4(texColor.rgb / texColor.a, texColor.a);
+            }
+            return vec4(0.0);
+    }}
+
     When display /disp/ has width /dispWidth/ height /dispHeight/ {
         # Create a canvas wrapper around the bare display so that you
         # can draw onto it using the canvas-oriented interface.
@@ -485,7 +511,7 @@ When the GPU library is /gpuLib/ & the GPU draw library is /drawLib/ &\
             set b [list $dispWidth 0]
             set c [list $dispWidth $dispHeight]
             set d [list 0 $dispHeight]
-            Wish the GPU draws pipeline "image" with arguments \
+            Wish the GPU draws pipeline "composite-canvas" with arguments \
                 [list [list $dispWidth $dispHeight] \
                      $surfaceToClip \
                      [dict get $canvOpts texture] $a $b $c $d]

--- a/builtin-programs/gpu/draw.folk
+++ b/builtin-programs/gpu/draw.folk
@@ -491,11 +491,11 @@ $cc proc createPipeline {VkShaderModule vertShaderModule
       VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT |
       VK_COLOR_COMPONENT_A_BIT;
     colorBlendAttachment.blendEnable = VK_TRUE;
-    colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+    colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
     colorBlendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
     colorBlendAttachment.colorBlendOp = VK_BLEND_OP_ADD;
     colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
-    colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+    colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
     colorBlendAttachment.alphaBlendOp = VK_BLEND_OP_ADD;
 
     VkPipelineColorBlendStateCreateInfo colorBlending = {0};
@@ -1018,7 +1018,7 @@ proc makeGpu {gpuLib drawLib} { return [library create gpu {gpuLib drawLib} {
             $[eval {
                 set samplerIdxs [lsearch -all -exact $pushConstants sampler2D]
                 proc emitFragInvocation {gpuSupportsDynamicIndexing pushConstants} { subst {
-                    outColor = frag([join [lmap {argtype argname} $pushConstants {
+                    vec4 rawColor = frag([join [lmap {argtype argname} $pushConstants {
                         if {$argname eq "_"} continue
                         if {$argtype eq "sampler2D"} {
                             if {$gpuSupportsDynamicIndexing} {
@@ -1033,7 +1033,10 @@ proc makeGpu {gpuLib drawLib} { return [library create gpu {gpuLib drawLib} {
                             expr {"args.$argname"}
                         }
                     }] ", "]);
-                } }
+
+                    // Premultiply the RGB
+                    outColor = vec4(rawColor.rgb * rawColor.a, rawColor.a);
+                }}
                 list
             }]
             void main() {


### PR DESCRIPTION
We aren't alpha-blending the shaders in the final compositing step so even sections of the shaders in the `/draw` directory that use `vec4(0, 0, 0, 0)` for transparency end up with black rectangles that bound the shapes they're drawing (e.g. the photo on the left). Using `discard` we get the behavior we expect, where overlapping shapes with transparent regions don't block each other.

## Before | After
<img height="400px" alt="before photo with shapes overlapping each other with black areas" src="https://github.com/user-attachments/assets/b915abf0-a736-44d2-80af-5aa9aea737c4" /> <img height="400px" alt="after photo with shapes correctly overlapping each other" src="https://github.com/user-attachments/assets/a8cbe4e0-4a35-4160-94d3-fa07f42ec35e" />

Also works on images:
<img width="400px" alt="IMG_5230" src="https://github.com/user-attachments/assets/fef79598-ad20-4e15-ad44-b2cf2165b187" />

