### PR TITLE
Refactor GPU to support multiple live displays; multiple live cameras

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ folk: workqueue.o db.o trie.o sysmon.o epoch.o folk.o output-redirection.o block
 
 %.o: %.c trie.h workqueue.h CFLAGS
 	cc -c -O2 -g -fno-omit-frame-pointer $(if $(ASAN_ENABLE),-fsanitize=address -fsanitize-recover=address,) -o$@  \
-		-D_GNU_SOURCE $(CFLAGS) $(BUILTIN_CFLAGS) \
+		-D_GNU_SOURCE -U_FORTIFY_SOURCE $(CFLAGS) $(BUILTIN_CFLAGS) \
 		$< -I./vendor/jimtcl -I./vendor/tracy/public
 
 folk_interpose.dylib: output-redirection.c

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ if flashing from a Mac] -- Ubuntu doesn't have a good kernel for Pi 5)
    `folk@folk-WHATEVER.local` by name, `sudo apt install avahi-daemon`
    and then on your laptop: `ssh-copy-id folk@folk-WHATEVER.local`
 
-1. Install dependencies: `sudo apt install rsync git cmake patchelf libturbojpeg0-dev libpng-dev libdrm-dev pkg-config v4l-utils vulkan-tools libvulkan-dev libvulkan1 meson libgbm-dev glslc vulkan-validationlayers ghostscript console-data kbd psmisc zlib1g-dev libssl-dev automake libtool autoconf-archive`
+1. Install dependencies: `sudo apt install rsync git cmake libturbojpeg0-dev libpng-dev libdrm-dev pkg-config v4l-utils vulkan-tools libvulkan-dev libvulkan1 meson libgbm-dev glslc vulkan-validationlayers ghostscript console-data kbd psmisc zlib1g-dev libssl-dev automake libtool autoconf-archive`
 
    (When prompted while installing `console-data` for `Policy for
    handling keymaps` type `3` (meaning `3. Keep kernel keymap`) and

--- a/boot.folk
+++ b/boot.folk
@@ -91,27 +91,15 @@ if {$::tcl_platform(os) eq "darwin"} {
         proc When args {
             set pattern [lrange $args 0 end-1]
 
-            if {{wishes} in $pattern && {display} ni $pattern} {
-                # HACK: This is a reactive handler (e.g. image-load
-                # in textures.folk) that should be async, not polled.
-                # Restore normal When and delegate.
-                rename When {}
-                rename When' When
-                tailcall When {*}$args
-            }
-
             # Await the dependencies being available.
             while {[llength [Query! {*}$pattern]] != 1} {
                 sleep 0.1
             }
 
-            if {{wishes} in $pattern && {display} in $pattern} {
-                # HACK: We're inside draw.folk's main When body now.
-                # Subsequent Whens (pipeline compilation, etc.) should
-                # be normal Whens and run off-thread/async.
-                rename When {}
-                rename When' When
-            }
+            # Restore real When before running the body, so any When
+            # calls inside the body register persistent async handlers.
+            rename When {}
+            rename When' When
 
             tailcall ForEach! {*}$args
         }
@@ -124,7 +112,8 @@ if {$::tcl_platform(os) eq "darwin"} {
         }
     }
     fake "builtin-programs/gpu/gpu.folk"
-    fake "builtin-programs/gpu/textures.folk"
-    fake "builtin-programs/gpu/pipelines.folk"
+    # textures.folk and pipelines.folk don't need the main thread
+    # (no GLFW/window work), so they run as normal async programs.
+    # draw.folk's fake When polls until their claims are available.
     fake "builtin-programs/gpu/draw.folk"
 }

--- a/boot.folk
+++ b/boot.folk
@@ -90,14 +90,25 @@ if {$::tcl_platform(os) eq "darwin"} {
         rename When When'
         proc When args {
             set pattern [lrange $args 0 end-1]
+
+            if {[lindex $pattern 0] eq {display}} {
+                # HACK: This is a display-dependent When inside
+                # textures.folk. Restore normal async When and delegate
+                # so it fires later when a display exists.
+                rename When {}
+                rename When' When
+                tailcall When {*}$args
+            }
+
             # Await the dependencies being available.
             while {[llength [Query! {*}$pattern]] != 1} {
                 sleep 0.1
             }
 
-            if {[lrange $pattern 0 3] eq {the GPU texture library}} {
-                # HACK: We want Whens inside this block to be normal
-                # Whens and run off-thread/async.
+            if {{wishes} in $pattern && {display} in $pattern} {
+                # HACK: We're inside draw.folk's main When body now.
+                # Subsequent Whens (pipeline compilation, etc.) should
+                # be normal Whens and run off-thread/async.
                 rename When {}
                 rename When' When
             }
@@ -107,9 +118,13 @@ if {$::tcl_platform(os) eq "darwin"} {
 
         source $s
 
-        rename When {}
-        rename When' When
+        if {[exists -command When']} {
+            rename When {}
+            rename When' When
+        }
     }
     fake "builtin-programs/gpu/gpu.folk"
+    fake "builtin-programs/gpu/textures.folk"
+    fake "builtin-programs/gpu/pipelines.folk"
     fake "builtin-programs/gpu/draw.folk"
 }

--- a/boot.folk
+++ b/boot.folk
@@ -91,10 +91,10 @@ if {$::tcl_platform(os) eq "darwin"} {
         proc When args {
             set pattern [lrange $args 0 end-1]
 
-            if {[lindex $pattern 0] eq {display}} {
-                # HACK: This is a display-dependent When inside
-                # textures.folk. Restore normal async When and delegate
-                # so it fires later when a display exists.
+            if {{wishes} in $pattern && {display} ni $pattern} {
+                # HACK: This is a reactive handler (e.g. image-load
+                # in textures.folk) that should be async, not polled.
+                # Restore normal When and delegate.
                 rename When {}
                 rename When' When
                 tailcall When {*}$args

--- a/builtin-programs/apriltags.folk
+++ b/builtin-programs/apriltags.folk
@@ -1,7 +1,22 @@
 When the image library is /imageLib/ {
 
 # To force a rebuild: rm -rf vendor/apriltag/build
-set apriltagFresh [expr {![file exists vendor/apriltag/build/libapriltag.so]}]
+
+# Older versions of this file ran `patchelf --set-soname` (linux) or
+# `install_name_tool -id @executable_path/...` (darwin) on the built
+# library so it could be located at load time. We now embed an rpath on
+# the wrapper instead, but if a previously-mutated library is sitting
+# on disk, force a clean rebuild so its identity goes back to the
+# default and the wrapper's rpath can resolve it. Heuristic: if the
+# build is older than this file, assume it predates the new scheme.
+if {[file exists vendor/apriltag/build] &&
+    [file exists vendor/apriltag/build/libapriltag.so] &&
+    [file mtime vendor/apriltag/build/libapriltag.so] < \
+        [file mtime $this]} {
+    puts "apriltags: stale libapriltag build detected, rebuilding..."
+    file delete -force vendor/apriltag/build
+}
+
 if {![file exists vendor/apriltag/build/Makefile]} {
     puts "apriltags: Configuring libapriltag..."
     exec cmake -B vendor/apriltag/build -S vendor/apriltag \
@@ -12,27 +27,30 @@ if {![file exists vendor/apriltag/build/Makefile]} {
 puts "apriltags: Building libapriltag..."
 exec cmake --build vendor/apriltag/build --target apriltag \
     >@stdout 2>@stderr
-if {$apriltagFresh} {
-    if {$::tcl_platform(os) eq "linux"} {
-        exec patchelf --set-soname "[pwd]/vendor/apriltag/build/libapriltag.so.3" \
-            vendor/apriltag/build/libapriltag.so.3
-    } elseif {$::tcl_platform(os) eq "darwin"} {
-        exec install_name_tool -id @executable_path/vendor/apriltag/build/libapriltag.dylib \
+
+if {$::tcl_platform(os) eq "darwin"} {
+    if {![file exists vendor/apriltag/build/libapriltag.so]} {
+        exec ln -sf libapriltag.dylib vendor/apriltag/build/libapriltag.so
+    }
+    set currentId [string trim [exec otool -D vendor/apriltag/build/libapriltag.dylib | tail -1]]
+    if {$currentId ne "@rpath/libapriltag.dylib"} {
+        exec install_name_tool -id @rpath/libapriltag.dylib \
             vendor/apriltag/build/libapriltag.dylib
-        if {![file exists vendor/apriltag/build/libapriltag.so]} {
-            exec ln -sf libapriltag.dylib vendor/apriltag/build/libapriltag.so
-        }
     }
 }
 puts "apriltags: libapriltag built."
-Claim libapriltag has been built
+
+fn configCcWithLibapriltag {cc} {
+    $cc cflags -I./vendor/apriltag
+    $cc endcflags -Wl,-rpath,[pwd]/vendor/apriltag/build \
+        ./vendor/apriltag/build/libapriltag.so
+}
+Claim libapriltag has been built with config [fn configCcWithLibapriltag]
 
 fn makeAprilTagDetector {TAG_FAMILY QUAD_DECIMATE NTHREADS} {
     set cc [C]
     $cc extend $imageLib
-
-    $cc cflags -I./vendor/apriltag
-    $cc endcflags ./vendor/apriltag/build/libapriltag.so
+    configCcWithLibapriltag $cc
     $cc include <apriltag.h>
     $cc include <$TAG_FAMILY.h>
     $cc include <math.h>

--- a/builtin-programs/calibrate/calibrate-page.folk
+++ b/builtin-programs/calibrate/calibrate-page.folk
@@ -271,33 +271,10 @@ Claim the calibration poses max is \${calibrationPosesMax}
               });
             </script>
 
-            <p>Use this camera preview to debug why printed and/or projected tags aren't being recognized (maybe overexposure, maybe your camera isn't in a good position): <button id="refreshButton">Refresh Preview</button> <input type="checkbox" value="true" id="autoRefreshCheckbox" checked>
-  <label for="autoRefreshCheckbox">Automatically refresh preview</label> </p><br> <span id="cameraPreview"></span>
-            <script>
-              const cameraWidth = $cameraWidth;
-              const cameraHeight = $cameraHeight;
-
-              refreshButton.onclick = function() {
-                if (typeof cameraFrame !== 'undefined') {
-                  cameraFrame.src = '/camera-frame?uniq=' + Math.random();
-                } else if (typeof cameraView !== 'undefined') {
-                  cameraView.src = cameraView.src;
-                }
-              };
-              function setupCameraPreview() {
-                const iframeWidth = 600;
-                const iframeHeight = Math.round(600 * cameraHeight / cameraWidth);
-                if (autoRefreshCheckbox.checked) {
-                  cameraPreview.innerHTML = `<iframe id="cameraView" src="/camera" width="\${iframeWidth}" height="\${iframeHeight}"></iframe>`;
-                } else {
-                  cameraPreview.innerHTML = `<img id="cameraFrame" src="/camera-frame" style="max-width: 100%">`;
-                }
-              }
-              setupCameraPreview();
-              autoRefreshCheckbox.addEventListener('change', () => {
-                setupCameraPreview();
-              });
-            </script>
+            <p>Use this camera preview to debug why printed and/or projected tags aren't being recognized (maybe overexposure, maybe your camera isn't in a good position):</p>
+            <iframe src="/camera?camera=[string map {/ %2F} $camera]"
+                    width="600" height="[expr {int(600.0 * $cameraHeight / $cameraWidth)}]"
+                    style="border: 1px solid #999;"></iframe>
 
 
             <p><strong>Is the projection too bright and washing out the camera?</strong>

--- a/builtin-programs/calibrate/calibrate-page.folk
+++ b/builtin-programs/calibrate/calibrate-page.folk
@@ -239,8 +239,10 @@ Wish the web server handles route "/calibrate" with hidden true handler {
             </script>
 
             <p>Once you start calibration, you'll see some AprilTags get automatically projected on your table. Move your board to the projected tags <em>so that at least one projected tag sits inside the gap between printed AprilTags</em>, wait a second for the projected tags to refit into the grid,
-          then <strong>hold the board still for a few seconds until
+              then <strong>hold the board still for a few seconds until
               the pose is recorded.</strong></p>
+
+            <p><strong>You should be lifting your board above the table plane and tilting it in the air. Don't just keep it flat on the table!</strong></p>
 
             <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/l1liP4_yiVM?si=DqgfNKq05EPBT3hT" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
@@ -273,7 +275,7 @@ Claim the calibration poses max is \${calibrationPosesMax}
 
             <p>Use this camera preview to debug why printed and/or projected tags aren't being recognized (maybe overexposure, maybe your camera isn't in a good position):</p>
             <iframe src="/camera?camera=$[string map {/ %2F} $camera]"
-                    width="600" height="$[expr {int(600.0 * $cameraHeight / $cameraWidth) + 48}]"
+                    width="600" height="$[expr {int(600.0 * $cameraHeight / $cameraWidth) + 84}]"
                     style="border: 1px solid #999;"></iframe>
 
           <p>Once you've recorded the first pose, <em>slowly drag the board around your space</em>, going slow enough for the projected AprilTags to catch up with the printed AprilTags and fit into the gaps on your board. When you've moved the board at least a full board-length away from the first pose, try to slant it 45 degrees or so off the table and hold it still again to capture another pose.</p>
@@ -449,7 +451,8 @@ When the calibration poses are /calibrationPoses/ {
         set width [dict get $pose cameraWidth]
         set height [dict get $pose cameraHeight]
         subst {
-          <li>
+          <li style="padding-bottom: 1em">
+          RMSE [dict getdef $pose rmse (unavailable)]
           <div style="position: relative; width: 300px; height: [expr {(300.0 / $width) * $height}]px">
             <img style="position: absolute; top: 0; left: 0; width: 300px; height: [expr {(300.0 / $width) * $height}]px"
                  src="/calibration-poses/[dict get $pose imageName]">
@@ -469,7 +472,6 @@ When the calibration poses are /calibrationPoses/ {
                 }] "\n"]
             </svg>
           </div>
-          RMSE [dict getdef $pose rmse (unavailable)]
           </li>
         }
       }] \n]

--- a/builtin-programs/calibrate/calibrate-page.folk
+++ b/builtin-programs/calibrate/calibrate-page.folk
@@ -272,46 +272,9 @@ Claim the calibration poses max is \${calibrationPosesMax}
             </script>
 
             <p>Use this camera preview to debug why printed and/or projected tags aren't being recognized (maybe overexposure, maybe your camera isn't in a good position):</p>
-            <iframe src="/camera?camera=[string map {/ %2F} $camera]"
-                    width="600" height="[expr {int(600.0 * $cameraHeight / $cameraWidth)}]"
+            <iframe src="/camera?camera=$[string map {/ %2F} $camera]"
+                    width="600" height="$[expr {int(600.0 * $cameraHeight / $cameraWidth) + 48}]"
                     style="border: 1px solid #999;"></iframe>
-
-
-            <p><strong>Is the projection too bright and washing out the camera?</strong>
-            <br/>
-            Adjust camera exposure:
-                <input type="range" min="10" max="48" value="15" class="slider" id="camera-exposure-slider">
-                <input type="number" min="1000" max="320000" step="100" value="1500" id="camera-exposure-number">μs
-            </p>
-
-            <script>
-            const slider = document.getElementById('camera-exposure-slider');
-            const numberInput = document.getElementById('camera-exposure-number');
-            let lastRefreshTimeout = null;
-            
-            function updateExposure(valueInMicroseconds) {
-                const sliderValue = valueInMicroseconds / 100;
-                
-                slider.value = sliderValue;
-                numberInput.value = valueInMicroseconds;
-                
-                ws.hold('exposure', tcl`
-                    Wish camera $camera uses exposure time \${valueInMicroseconds} us
-                `, 'builtin-programs/calibrate/calibrate.folk');
-            }
-            
-            slider.addEventListener('input', (e) => {
-                const exposureValue = Math.round(e.target.value * 100);
-                updateExposure(exposureValue);
-            });
-            
-            numberInput.addEventListener('input', (e) => {
-                const exposureValue = parseInt(e.target.value);
-                updateExposure(exposureValue);
-            });
-            
-            updateExposure(10000);
-            </script>
 
           <p>Once you've recorded the first pose, <em>slowly drag the board around your space</em>, going slow enough for the projected AprilTags to catch up with the printed AprilTags and fit into the gaps on your board. When you've moved the board at least a full board-length away from the first pose, try to slant it 45 degrees or so off the table and hold it still again to capture another pose.</p>
 

--- a/builtin-programs/calibrate/calibrate.folk
+++ b/builtin-programs/calibrate/calibrate.folk
@@ -156,7 +156,7 @@ When camera /camera/ has width /cameraWidth/ height /cameraHeight/ &\
         set camResults [Query! /someone/ wishes $::thisNode uses camera $camera with /...camOpts/]
         if {[llength $camResults] == 1} {
             set camOpts [dict get [lindex $camResults 0] camOpts]
-            if {![dict exists $camOpts crop]} {
+            if {![dict exists $camOpts crops]} {
                 Retract! /someone/ wishes $::thisNode uses camera $camera \
                     with width $cameraWidth height $cameraHeight
                 Assert! $this wishes $::thisNode uses camera $camera \

--- a/builtin-programs/calibrate/calibrate.folk
+++ b/builtin-programs/calibrate/calibrate.folk
@@ -374,9 +374,6 @@ When camera /camera/ has width /cameraWidth/ height /cameraHeight/ &\
 
     On unmatch {
         Hold! -key H_modelToDisplay {}
-        Hold! -key exposure {
-            Wish camera $camera uses exposure time auto us
-        }
     }
 
     When the calibration poses max is /calibrationPosesMax/ &\

--- a/builtin-programs/calibrate/matlib.folk
+++ b/builtin-programs/calibrate/matlib.folk
@@ -1,10 +1,11 @@
-When libapriltag has been built {
+When libapriltag has been built with config /configCcWithLibapriltag/ {
+fn configCcWithLibapriltag
 
 # We try to use the AprilTag matrix library (instead of tcllib linalg)
 # to do matrix/homography operations in the live calibration inner
 # loop, to help with performance:
 set cc [C]
-$cc cflags -I./vendor/apriltag
+configCcWithLibapriltag $cc
 $cc include <math.h>
 $cc include <common/matd.h>
 $cc include <common/homography.h>
@@ -247,7 +248,6 @@ $cc proc applyHomography {matd_t* H double[2] xy} Jim_Obj* {
 $cc proc matdMul {matd_t* a matd_t* b} matd_t* {
     return matd_multiply(a, b);
 }
-$cc endcflags ./vendor/apriltag/build/libapriltag.so
 set matLib [$cc compile]
 Claim the calibration matLib is $matLib
 

--- a/builtin-programs/calibrate/refine.folk
+++ b/builtin-programs/calibrate/refine.folk
@@ -5,7 +5,8 @@
 #     cmpfit.
 #
 
-When libapriltag has been built {
+When libapriltag has been built with config /configCcWithLibapriltag/ {
+fn configCcWithLibapriltag
 
 # From https://courses.cs.duke.edu/cps274/fall13/notes/rodrigues.pdf:
 fn rotationMatrixToRotationVector {R} {
@@ -62,8 +63,8 @@ fn rotationVectorToRotationMatrix {r} {
 set NUM_TAGS_IN_MODEL 20
 
 set cc [C]
-$cc cflags -I./vendor/cmpfit -I./vendor/apriltag -Wall -Werror
-$cc endcflags ./vendor/apriltag/build/libapriltag.so
+$cc cflags -I./vendor/cmpfit -Wall -Werror
+configCcWithLibapriltag $cc
 
 $cc include <math.h>
 $cc include <string.h>

--- a/builtin-programs/camera/usb.folk
+++ b/builtin-programs/camera/usb.folk
@@ -370,7 +370,7 @@ When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
     # Outer, retry loop.
     while true {
         set camObj {}
-        try {
+        try -signal {
             runCamera camObj
         } on error e {
             puts stderr "camera/usb: Error $e"

--- a/builtin-programs/camera/usb.folk
+++ b/builtin-programs/camera/usb.folk
@@ -293,18 +293,10 @@ When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
     set height [dict get $options height]
     set bufferCount [dict getdef $options bufferCount 2]
 
-    if {[dict exists $options crop]} {
-        set crop [dict get $options crop]
+    if {[dict exists $options crops]} {
+        set crops [dict get $options crops]
     }
 
-    if {[info exists crop]} {
-        set decompressWidth [dict get $crop width]
-        set decompressHeight [dict get $crop height]
-    } else {
-        set decompressWidth $width
-        set decompressHeight $height
-    }
-    
     set camObj [$camLib cameraOpen $camera $width $height]
     puts "camera/usb: Loaded $camera -> $camObj"
     $camLib cameraInit $camObj $bufferCount
@@ -315,8 +307,31 @@ When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
     }
 
     try -signal {
-        if {[info exists crop]} {
-            Claim camera $camera has width [dict get $crop width] height [dict get $crop height]
+        if {[info exists crops]} {
+            for {set i 0} {$i < [llength $crops]} {incr i} {
+                set cropPath [list $camera $i]
+                set cropWidth [dict get [lindex $crops $i] width]
+                set cropHeight [dict get [lindex $crops $i] height]
+
+                Claim camera $cropPath has width $cropWidth height $cropHeight
+
+                When camera $cropPath has jpeg frame /jpeg/ at timestamp /ts/ {
+                    set grayImage [$jpegLib jpegDecompressGray $jpeg \
+                                       $cropWidth $cropHeight \
+                                       [expr {int($ts * 1000)}]]
+                    Hold! -key [list camera $cropPath gray-frame] \
+                        Claim camera $cropPath has gray frame $grayImage at timestamp $ts \
+                        -destructor [list $imageLib imageFree $grayImage]
+                }
+                When camera $cropPath has jpeg frame /jpeg/ at timestamp /ts/ {
+                    set frameImage [$jpegLib jpegDecompressRGB $jpeg \
+                                        $cropWidth $cropHeight \
+                                        [expr {int($ts * 1000)}]]
+                    Hold! -key [list camera $cropPath frame] \
+                        Claim camera $cropPath has frame $frameImage at timestamp $ts \
+                        -destructor [list $imageLib imageFree $frameImage]
+                }
+            }
         } else {
             Claim camera $camera has width $width height $height
         }
@@ -329,21 +344,23 @@ When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
             }
         }
 
-        When camera $camera has jpeg frame /jpeg/ at timestamp /ts/ {
-            set grayImage [$jpegLib jpegDecompressGray $jpeg \
-                               $decompressWidth $decompressHeight \
-                               [expr {int($ts * 1000)}]]
-            Hold! -key [list camera $camera gray-frame] \
-                Claim camera $camera has gray frame $grayImage at timestamp $ts \
-                -destructor [list $imageLib imageFree $grayImage]
-        }
-        When camera $camera has jpeg frame /jpeg/ at timestamp /ts/ {
-            set frameImage [$jpegLib jpegDecompressRGB $jpeg \
-                                $decompressWidth $decompressHeight \
-                                [expr {int($ts * 1000)}]]
-            Hold! -key [list camera $camera frame] \
-                Claim camera $camera has frame $frameImage at timestamp $ts \
-                -destructor [list $imageLib imageFree $frameImage]
+        if {![info exists crops]} {
+            When camera $camera has jpeg frame /jpeg/ at timestamp /ts/ {
+                set grayImage [$jpegLib jpegDecompressGray $jpeg \
+                                   $width $height \
+                                   [expr {int($ts * 1000)}]]
+                Hold! -key [list camera $camera gray-frame] \
+                    Claim camera $camera has gray frame $grayImage at timestamp $ts \
+                    -destructor [list $imageLib imageFree $grayImage]
+            }
+            When camera $camera has jpeg frame /jpeg/ at timestamp /ts/ {
+                set frameImage [$jpegLib jpegDecompressRGB $jpeg \
+                                    $width $height \
+                                    [expr {int($ts * 1000)}]]
+                Hold! -key [list camera $camera frame] \
+                    Claim camera $camera has frame $frameImage at timestamp $ts \
+                    -destructor [list $imageLib imageFree $frameImage]
+            }
         }
 
         while true {
@@ -351,22 +368,30 @@ When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
 
             set ms [clock milliseconds]
             set jpeg [$camLib cameraFrameJpeg $camObj]
-
-            if {[info exists crop]} {
-                dict with crop {
-                    set croppedJpeg [$jpegLib jpegSubimage $jpeg \
-                                         $x $y $width $height]
-                }
-                $camLib jpegFree $jpeg
-            } else {
-                set croppedJpeg $jpeg
-            }
             set timestamp [expr {$ms / 1000.0}]
             tracy zoneName "camera/usb: $timestamp"
 
+            if {[info exists crops]} {
+                for {set i 0} {$i < [llength $crops]} {incr i} {
+                    set crop [lindex $crops $i]
+                    set cropPath [list $camera $i]
+                    set croppedJpeg [$jpegLib jpegSubimage $jpeg \
+                                         [dict get $crop x] \
+                                         [dict get $crop y] \
+                                         [dict get $crop width] \
+                                         [dict get $crop height]]
+                    Hold! -key [list camera $cropPath jpeg] \
+                        Claim camera $cropPath has jpeg frame $croppedJpeg at timestamp $timestamp \
+                        -destructor [list $camLib jpegFree $croppedJpeg]
+                }
+            }
+            # Always publish the source jpeg so the preview keeps working
+            # even when virtual crops are configured. Gray/RGB decompressors
+            # on the source camera are gated off in crops mode to avoid
+            # full-resolution decoding.
             Hold! -key [list camera $camera jpeg] \
-                Claim camera $camera has jpeg frame $croppedJpeg at timestamp $timestamp \
-                -destructor [list $camLib jpegFree $croppedJpeg]
+                Claim camera $camera has jpeg frame $jpeg at timestamp $timestamp \
+                -destructor [list $camLib jpegFree $jpeg]
 
             tracy zoneEnd
         }

--- a/builtin-programs/camera/usb.folk
+++ b/builtin-programs/camera/usb.folk
@@ -73,7 +73,17 @@ $camc proc cameraOpen {char* device int width int height} Camera* {
 $camc proc cameraClose {Camera* camera} void {
     enum v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
     if (xioctl(camera->fd, VIDIOC_STREAMOFF, &type) == -1) {
-        quit("VIDIOC_STREAMOFF");
+        // if ENODEV, we're already done; just return to caller.
+        if (errno == ENODEV) {
+            fprintf(stderr, "cameraClose (%p): ENODEV, returning.\n",
+                    camera);
+            close(camera->fd);
+            free(camera);
+            return;
+        } else {
+            // stop, something weird happened.
+            quit("VIDIOC_STREAMOFF");
+        }
     }
 
     struct v4l2_requestbuffers req = {0};
@@ -293,9 +303,14 @@ When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
         set crops [dict get $options crops]
     }
 
-    fn runCamera {} {
-        set camObj [$camLib cameraOpen $camera $width $height]
+    fn runCamera {camObjVar} {
+        puts "camera/usb: Will try to open $camera"
+
+        upvar $camObjVar camObj_
+        set camObj_ [$camLib cameraOpen $camera $width $height]
+        set camObj $camObj_ ;# HACK: we don't capture upvars yet.
         puts "camera/usb: Loaded $camera -> $camObj"
+
         $camLib cameraInit $camObj $bufferCount
         $camLib cameraStart $camObj
         # skip 5 frames for booting a cam
@@ -354,8 +369,9 @@ When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
 
     # Outer, retry loop.
     while true {
+        set camObj {}
         try {
-            runCamera
+            runCamera camObj
         } on error e {
             puts stderr "camera/usb: Error $e"
         } on signal sig {
@@ -363,8 +379,10 @@ When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
             # This is actually a termination condition.
             break
         } finally {
-            puts "camera/usb: Close $camObj"
-            $camLib cameraClose $camObj
+            if {$camObj ne {}} {
+                puts "camera/usb: Close $camObj"
+                $camLib cameraClose $camObj
+            }
         }
 
         # We only get down here if something goes wrong. Wait before

--- a/builtin-programs/camera/usb.folk
+++ b/builtin-programs/camera/usb.folk
@@ -261,6 +261,25 @@ $camc proc setExposureAuto {Camera* camera} void {
 $camc cflags -Wall -Werror
 set camLib [$camc compile]
 
+When camera /cameraPath/ has width /decompWidth/ height /decompHeight/ {
+    When camera $cameraPath has jpeg frame /jpeg/ at timestamp /ts/ {
+        set grayImage [$jpegLib jpegDecompressGray $jpeg \
+                           $decompWidth $decompHeight \
+                           [expr {int($ts * 1000)}]]
+        Hold! -key [list camera $cameraPath gray-frame] \
+            Claim camera $cameraPath has gray frame $grayImage at timestamp $ts \
+            -destructor [list $imageLib imageFree $grayImage]
+    }
+    When camera $cameraPath has jpeg frame /jpeg/ at timestamp /ts/ {
+        set frameImage [$jpegLib jpegDecompressRGB $jpeg \
+                            $decompWidth $decompHeight \
+                            [expr {int($ts * 1000)}]]
+        Hold! -key [list camera $cameraPath frame] \
+            Claim camera $cameraPath has frame $frameImage at timestamp $ts \
+            -destructor [list $imageLib imageFree $frameImage]
+    }
+}
+
 When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
     if {[string match "/sys/bus/usb/devices/*" $camera]} {
         set devicePath $camera
@@ -309,28 +328,9 @@ When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
     try -signal {
         if {[info exists crops]} {
             for {set i 0} {$i < [llength $crops]} {incr i} {
-                set cropPath [list $camera $i]
-                set cropWidth [dict get [lindex $crops $i] width]
-                set cropHeight [dict get [lindex $crops $i] height]
-
-                Claim camera $cropPath has width $cropWidth height $cropHeight
-
-                When camera $cropPath has jpeg frame /jpeg/ at timestamp /ts/ {
-                    set grayImage [$jpegLib jpegDecompressGray $jpeg \
-                                       $cropWidth $cropHeight \
-                                       [expr {int($ts * 1000)}]]
-                    Hold! -key [list camera $cropPath gray-frame] \
-                        Claim camera $cropPath has gray frame $grayImage at timestamp $ts \
-                        -destructor [list $imageLib imageFree $grayImage]
-                }
-                When camera $cropPath has jpeg frame /jpeg/ at timestamp /ts/ {
-                    set frameImage [$jpegLib jpegDecompressRGB $jpeg \
-                                        $cropWidth $cropHeight \
-                                        [expr {int($ts * 1000)}]]
-                    Hold! -key [list camera $cropPath frame] \
-                        Claim camera $cropPath has frame $frameImage at timestamp $ts \
-                        -destructor [list $imageLib imageFree $frameImage]
-                }
+                set crop [lindex $crops $i]
+                Claim camera [list $camera $i] has width [dict get $crop width] \
+                    height [dict get $crop height]
             }
         } else {
             Claim camera $camera has width $width height $height
@@ -341,25 +341,6 @@ When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
                 $camLib setExposureAuto $camObj
             } else {
                 $camLib setExposure $camObj [expr {int($exposureTimeUs / 100)}]
-            }
-        }
-
-        if {![info exists crops]} {
-            When camera $camera has jpeg frame /jpeg/ at timestamp /ts/ {
-                set grayImage [$jpegLib jpegDecompressGray $jpeg \
-                                   $width $height \
-                                   [expr {int($ts * 1000)}]]
-                Hold! -key [list camera $camera gray-frame] \
-                    Claim camera $camera has gray frame $grayImage at timestamp $ts \
-                    -destructor [list $imageLib imageFree $grayImage]
-            }
-            When camera $camera has jpeg frame /jpeg/ at timestamp /ts/ {
-                set frameImage [$jpegLib jpegDecompressRGB $jpeg \
-                                    $width $height \
-                                    [expr {int($ts * 1000)}]]
-                Hold! -key [list camera $camera frame] \
-                    Claim camera $camera has frame $frameImage at timestamp $ts \
-                    -destructor [list $imageLib imageFree $frameImage]
             }
         }
 

--- a/builtin-programs/camera/usb.folk
+++ b/builtin-programs/camera/usb.folk
@@ -243,19 +243,21 @@ $camc proc jpegFree {CameraBuffer jpeg} void {
 $camc proc setExposure {Camera* camera int value} void {
     struct v4l2_control c;
 
-    c.id = V4L2_CID_EXPOSURE_AUTO;
-    c.value = V4L2_EXPOSURE_MANUAL;
-    FOLK_ENSURE(xioctl(camera->fd, VIDIOC_S_CTRL, &c) == 0);
+    fprintf(stderr, "setExposure %d\n", value);
+    if (value == 0) {
+        c.id = V4L2_CID_EXPOSURE_AUTO;
+        c.value = V4L2_EXPOSURE_APERTURE_PRIORITY;
+        FOLK_ENSURE(xioctl(camera->fd, VIDIOC_S_CTRL, &c) == 0);
 
-    c.id = V4L2_CID_EXPOSURE_ABSOLUTE;
-    c.value = value;
-    FOLK_ENSURE(xioctl(camera->fd, VIDIOC_S_CTRL, &c) == 0);
-}
-$camc proc setExposureAuto {Camera* camera} void {
-    struct v4l2_control c;
-    c.id = V4L2_CID_EXPOSURE_AUTO;
-    c.value = V4L2_EXPOSURE_APERTURE_PRIORITY;
-    FOLK_ENSURE(xioctl(camera->fd, VIDIOC_S_CTRL, &c) == 0);
+    } else {
+        c.id = V4L2_CID_EXPOSURE_AUTO;
+        c.value = V4L2_EXPOSURE_MANUAL;
+        FOLK_ENSURE(xioctl(camera->fd, VIDIOC_S_CTRL, &c) == 0);
+
+        c.id = V4L2_CID_EXPOSURE_ABSOLUTE;
+        c.value = value;
+        FOLK_ENSURE(xioctl(camera->fd, VIDIOC_S_CTRL, &c) == 0);
+    }
 }
 
 $camc cflags -Wall -Werror
@@ -281,31 +283,6 @@ When camera /cameraPath/ has width /decompWidth/ height /decompHeight/ {
 }
 
 When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
-    if {[string match "/sys/bus/usb/devices/*" $camera]} {
-        set devicePath $camera
-
-        fn retryDevice {} {
-            set videoDevices [glob -nocomplain [file join $devicePath video4linux video*]]
-            if {[llength $videoDevices] > 0} {
-                set camera [file tail [lindex [lsort -dict $videoDevices] 0]]
-                set camera "/dev/$camera"
-            } else {
-                error "camera/usb: Unable to find video device for $devicePath"
-            }
-
-            Hold! -key [list retry $devicePath] \
-                Wish $::thisNode uses camera $camera with {*}$options
-        }
-
-        When camera $camera failed with error /e/ {
-            puts stderr "camera/usb: Restarting after failure with $e"
-            retryDevice
-        }
-        retryDevice
-
-        return
-    }
-
     if {![string match "/dev/*" $camera]} { return }
 
     set width [dict get $options width]
@@ -316,16 +293,16 @@ When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
         set crops [dict get $options crops]
     }
 
-    set camObj [$camLib cameraOpen $camera $width $height]
-    puts "camera/usb: Loaded $camera -> $camObj"
-    $camLib cameraInit $camObj $bufferCount
-    $camLib cameraStart $camObj
-    # skip 5 frames for booting a cam
-    for {set i 0} {$i < 5} {incr i} {
-        $camLib cameraFrameJpeg $camObj
-    }
+    fn runCamera {} {
+        set camObj [$camLib cameraOpen $camera $width $height]
+        puts "camera/usb: Loaded $camera -> $camObj"
+        $camLib cameraInit $camObj $bufferCount
+        $camLib cameraStart $camObj
+        # skip 5 frames for booting a cam
+        for {set i 0} {$i < 5} {incr i} {
+            $camLib cameraFrameJpeg $camObj
+        }
 
-    try -signal {
         if {[info exists crops]} {
             for {set i 0} {$i < [llength $crops]} {incr i} {
                 set crop [lindex $crops $i]
@@ -337,13 +314,10 @@ When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
         }
 
         When /someone/ wishes camera $camera uses exposure time /exposureTimeUs/ us {
-            if {$exposureTimeUs eq "auto"} {
-                $camLib setExposureAuto $camObj
-            } else {
-                $camLib setExposure $camObj [expr {int($exposureTimeUs / 100)}]
-            }
+            $camLib setExposure $camObj [expr {int($exposureTimeUs / 100)}]
         }
 
+        # Inner, frame loop.
         while true {
             tracy zoneBegin
 
@@ -376,15 +350,26 @@ When /someone/ wishes $::thisNode uses camera /camera/ with /...options/ {
 
             tracy zoneEnd
         }
-    } on error e {
-        puts stderr "camera/usb: Error $e"
-        Hold! -key [list camera-error $camera] \
-            Claim camera $camera failed with error $e
-    } on signal sig {
-        puts stderr "camera/usb: Signal $sig"
-    } finally {
-        puts "camera/usb: Close $camObj"
-        $camLib cameraClose $camObj
+    }
+
+    # Outer, retry loop.
+    while true {
+        try {
+            runCamera
+        } on error e {
+            puts stderr "camera/usb: Error $e"
+        } on signal sig {
+            puts stderr "camera/usb: Signal $sig"
+            # This is actually a termination condition.
+            break
+        } finally {
+            puts "camera/usb: Close $camObj"
+            $camLib cameraClose $camObj
+        }
+
+        # We only get down here if something goes wrong. Wait before
+        # trying to restart the camera.
+        sleep 1
     }
 }
 

--- a/builtin-programs/draw/image.folk
+++ b/builtin-programs/draw/image.folk
@@ -86,7 +86,7 @@ Wish the GPU compiles pipeline "image" {
         if( max( abs(uv.x-0.5), abs(uv.y-0.5))<0.5 ) {
             vec4 texColor = texture(image, uv);
 
-            if ((texColor.a < 0.01) || (texColor.r < 0.05 && texColor.g < 0.05 && texColor.b < 0.05)) {
+            if (texColor.a < 0.01) {
                 return vec4(0.0);
             }
 

--- a/builtin-programs/gpu/canvases.folk
+++ b/builtin-programs/gpu/canvases.folk
@@ -28,9 +28,10 @@ When the GPU library is /gpuLib/ &\
 
     $gpuc code {
         VkDevice device;
-        // Canvas textures don't need to match the swapchain format;
-        // they just need a consistent format for render pass + texture.
-        VkFormat canvasFormat = VK_FORMAT_B8G8R8A8_SRGB;
+        // Canvas format must match the pipeline render pass format
+        // (VK_FORMAT_B8G8R8A8_UNORM) so that shared pipelines are
+        // render-pass-compatible when drawing onto canvases.
+        VkFormat canvasFormat = VK_FORMAT_B8G8R8A8_UNORM;
 
         // This render pass is used to draw on all canvases.
         VkRenderPass renderPass;
@@ -139,9 +140,9 @@ When the GPU library is /gpuLib/ &\
         free(wi);
     }
     $gpuc code {
-        GpuCanvas* boundCanvas;
-        VkPipeline boundPipeline;
-        VkDescriptorSet boundDescriptorSet;
+        __thread GpuCanvas* boundCanvas;
+        __thread VkPipeline boundPipeline;
+        __thread VkDescriptorSet boundDescriptorSet;
     }
     $gpuc proc drawStart {GpuCanvas* wi} void {
         FOLK_ENSURE(boundCanvas == NULL);
@@ -261,13 +262,10 @@ When the GPU library is /gpuLib/ &\
     set gpuCanvasLib [$gpuc compile]
     Claim the GPU canvas library is $gpuCanvasLib
 
-    # We need to wait until the GPU is online and registered the
-    # display before we set up the canvas subsystem.
-    When display /any/ has width /any/ height /any/ {
-        $gpuCanvasLib init
+    $gpuCanvasLib init
 
-        # `id` is arbitrarily chosen by the caller:
-        When /someone/ wishes the GPU creates canvas /id/ with /...options/ {
+    # `id` is arbitrarily chosen by the caller:
+    When /someone/ wishes the GPU creates canvas /id/ with /...options/ {
             set width [dict get $options width]
             set height [dict get $options height]
             set settle [dict getdef $options settle 3ms]
@@ -425,7 +423,6 @@ When the GPU library is /gpuLib/ &\
                 StatementRelease! $ref
             }
         }} $gpuCanvasLib]
-    }
 
     When /someone/ wishes /p/ has a canvas {
         Wish $p has a canvas with width 1024 height 1024 settle 3ms

--- a/builtin-programs/gpu/canvases.folk
+++ b/builtin-programs/gpu/canvases.folk
@@ -1,25 +1,21 @@
-When the GPU library is /gpuLib/ & the GPU draw library is /drawLib/ &\
+When the GPU library is /gpuLib/ &\
      the image library is /imageLib/ &\
-     the GPU texture library for /drawLib/ is /gpuTextureLib/ {
+     the GPU pipeline library is /pipelineLib/ &\
+     the GPU texture library is /gpuTextureLib/ {
     set gpuc [C]
     $gpuc include <pthread.h>
     $gpuc cflags -I./vendor
     $gpuc code {
         #define VOLK_IMPLEMENTATION
         #include "volk/volk.h"
-
-        typedef struct PushConstantsEncoder {
-            int (*encode)(Jim_Interp* interp, Jim_Obj* obj, uint8_t out[128]);
-        } PushConstantsEncoder;
     }
-    $gpuc typedef {struct Pipeline} Pipeline
 
     $gpuc extend -noprocs $gpuLib
-    $gpuc extend -noprocs $drawLib
     $gpuc import $gpuLib VkResultToString
-    $gpuc import $drawLib getCommandBuffer
+    $gpuc import $gpuLib getCommandBuffer
 
     $gpuc extend $imageLib
+    $gpuc extend -noprocs $pipelineLib
     $gpuc extend $gpuTextureLib
 
     local proc vktry {call} { string map {\n " "} [csubst {{
@@ -32,7 +28,9 @@ When the GPU library is /gpuLib/ & the GPU draw library is /drawLib/ &\
 
     $gpuc code {
         VkDevice device;
-        VkFormat swapchainImageFormat;
+        // Canvas textures don't need to match the swapchain format;
+        // they just need a consistent format for render pass + texture.
+        VkFormat canvasFormat = VK_FORMAT_B8G8R8A8_SRGB;
 
         // This render pass is used to draw on all canvases.
         VkRenderPass renderPass;
@@ -44,12 +42,10 @@ When the GPU library is /gpuLib/ & the GPU draw library is /drawLib/ &\
         device = *device_ptr();
         volkLoadDevice(device);
 
-        swapchainImageFormat = *swapchainImageFormat_ptr();
-
         // Set up VkRenderPass renderPass:
         {
             VkAttachmentDescription colorAttachment = {0};
-            colorAttachment.format = swapchainImageFormat;
+            colorAttachment.format = canvasFormat;
             colorAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
             colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
             colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
@@ -107,10 +103,10 @@ When the GPU library is /gpuLib/ & the GPU draw library is /drawLib/ &\
         GpuCanvas* wi = malloc(sizeof(GpuCanvas));
         wi->extent.width = width; wi->extent.height = height;
 
-        GpuTextureBlock* block = createGpuTexture(width, height, swapchainImageFormat);
+        GpuTextureBlock* block = createGpuTexture(width, height, canvasFormat);
         wi->gpuTexture = block->handle;
         // make it immediately renderable
-        transitionImageLayout(block->textureImage, swapchainImageFormat,
+        transitionImageLayout(block->textureImage, canvasFormat,
                               VK_IMAGE_LAYOUT_UNDEFINED,
                               VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
         addToTextureDescriptorSet(block->handle);
@@ -263,7 +259,7 @@ When the GPU library is /gpuLib/ & the GPU draw library is /drawLib/ &\
     }
 
     set gpuCanvasLib [$gpuc compile]
-    Claim the GPU canvas library for $drawLib is $gpuCanvasLib
+    Claim the GPU canvas library is $gpuCanvasLib
 
     # We need to wait until the GPU is online and registered the
     # display before we set up the canvas subsystem.

--- a/builtin-programs/gpu/draw.folk
+++ b/builtin-programs/gpu/draw.folk
@@ -2,6 +2,7 @@
 #
 #     Provides the ability to run pixel shaders with image and
 #     numerical parameters (so you can draw images, shapes, etc.)
+#     Single render thread handles all displays.
 
 if {[info exists this] && $::tcl_platform(os) eq "darwin"} {
     # We hard-code draw.folk into thread 0, so we should abort if not
@@ -11,11 +12,13 @@ if {[info exists this] && $::tcl_platform(os) eq "darwin"} {
 
 When the GPU library is /gpuLib/ &\
      the GPU Vulkan handle type definer is /defineVulkanHandleType/ &\
-     the GPU pipeline library is /pipelineLib/ &\
-     /someone/ wishes $::thisNode uses display /display/ with /...displayOpts/ {
+     the GPU pipeline library is /pipelineLib/ {
 
 fn defineVulkanHandleType
-set useGlfw $($display eq "glfw")
+
+# On macOS we always use GLFW; on Linux we use direct Vulkan display.
+# (On macOS, draw.folk returns early above, so this only runs on Linux.)
+set useGlfw false
 
 set cc [C]
 $cc cflags -I./vendor
@@ -25,13 +28,6 @@ $cc include <pthread.h>
 $cc code {
     #define VOLK_IMPLEMENTATION
     #include "volk/volk.h"
-}
-if {$useGlfw} {
-    $cc code {
-        // This must be included _after_ volk.h (Vulkan).
-        #include <GLFW/glfw3.h>
-    }
-    $cc endcflags -lglfw
 }
 
 $cc extend $gpuLib
@@ -45,27 +41,42 @@ local proc vktry {call} { string map {\n " "} [csubst {{
     }
 }}] }
 
-$cc define {
-    VkSwapchainKHR swapchain;
-    uint32_t swapchainImageCount;
-    VkFormat swapchainImageFormat;
-    VkFramebuffer* swapchainFramebuffers;
-    VkExtent2D swapchainExtent;
-
-    uint32_t imageIndex;
-
-    VkSemaphore imageAvailableSemaphore;
-    VkSemaphore renderFinishedSemaphore;
-    VkFence inFlightFence;
-}
-
 $cc code {
+    typedef struct DisplayState {
+        VkSurfaceKHR surface;
+        VkSwapchainKHR swapchain;
+        uint32_t swapchainImageCount;
+        VkFormat swapchainImageFormat;
+        VkFramebuffer* swapchainFramebuffers;
+        VkExtent2D swapchainExtent;
+
+        uint32_t imageIndex;
+
+        VkSemaphore imageAvailableSemaphore;
+        VkSemaphore renderFinishedSemaphore;
+        VkFence inFlightFence;
+    } DisplayState;
+
     VkDevice device;
     VkPhysicalDevice physicalDevice;
+
+    static DisplayState* currentDisplay;
+    static VkPipeline boundPipeline;
+    static VkDescriptorSet boundDescriptorSet;
 }
 
-$cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refreshRate} void {
-    $[vktry volkInitialize()]
+$cc argtype DisplayState* {
+    DisplayState* $argname;
+    sscanf(Jim_String($obj), "(DisplayState*) %p", &$argname);
+}
+$cc rtype DisplayState* {
+    char buf[100];
+    snprintf(buf, 100, "(DisplayState*) %p", $rvalue);
+    $robj = Jim_NewStringObj(interp, buf, -1);
+}
+
+$cc proc initDisplay {char* display uint32_t width uint32_t height uint32_t refreshRate} DisplayState* {
+    volkInitialize();
     volkLoadInstanceOnly(*instance_ptr());
 
     device = *device_ptr();
@@ -73,17 +84,10 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
 
     physicalDevice = *physicalDevice_ptr();
 
+    DisplayState* ds = calloc(1, sizeof(DisplayState));
+
     // Get drawing surface.
-    VkSurfaceKHR surface;
-    $[expr { $useGlfw ? {
-        GLFWwindow* window;
-        glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-        window = glfwCreateWindow(width, height, "Folk", NULL, NULL);
-        FOLK_ENSURE(window != NULL);
-        if (glfwCreateWindowSurface(*instance_ptr(), window, NULL, &surface) != VK_SUCCESS) {
-            FOLK_ERROR("Failed to create GLFW window surface");
-        }
-    } : [csubst {
+    $[csubst {
         // Search through displays to find the one matching display name
         int retries = 0;
         VkDisplayKHR chosenDisplay = VK_NULL_HANDLE;
@@ -105,6 +109,7 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
 
             retries++;
             if (retries > 10) {
+                free(ds);
                 FOLK_ERROR("Failed to find display '%s'\n", display);
             } else {
                 fprintf(stderr, "gpu/draw: Failed to find display '%s'; retrying (retry %d).\n",
@@ -130,15 +135,13 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
             }
         }
         if (chosenMode == -1) {
+            free(ds);
             FOLK_ERROR("Failed to find display mode on display '%s' "
                        "with width=%u height=%u refreshRate=%u\n",
                        display, width, height, refreshRate);
         }
 
         // Find a display plane that supports chosenDisplay.
-        // Lock so two display threads don't pick the same plane.
-        pthread_mutex_lock(displaySurfaceMutex_ptr());
-
         uint32_t planeCount;
         vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, &planeCount, NULL);
         VkDisplayPlanePropertiesKHR planeProps[planeCount];
@@ -164,8 +167,9 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
             }
             if (chosenPlane != UINT32_MAX) break;
         }
+        fprintf(stderr, "chosenPlane for '%s': %u\n", display, chosenPlane);
         if (chosenPlane == UINT32_MAX) {
-            pthread_mutex_unlock(displaySurfaceMutex_ptr());
+            free(ds);
             FOLK_ERROR("Failed to find a display plane for display '%s'\n", display);
         }
 
@@ -176,17 +180,12 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
         createInfo.transform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
         createInfo.alphaMode = VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR;
         createInfo.imageExtent = modeProps[chosenMode].parameters.visibleRegion;
-        if (vkCreateDisplayPlaneSurfaceKHR(*instance_ptr(), &createInfo, NULL, &surface) != VK_SUCCESS) {
-            pthread_mutex_unlock(displaySurfaceMutex_ptr());
-            fprintf(stderr, "Failed to create Vulkan display plane surface\n"); exit(1);
-        }
-
-        pthread_mutex_unlock(displaySurfaceMutex_ptr());
-    }] }]
+        $[vktry {vkCreateDisplayPlaneSurfaceKHR(*instance_ptr(), &createInfo, NULL, &ds->surface)}]
+    }]
 
     uint32_t presentQueueFamilyIndex; {
-        VkBool32 presentSupport = 0; 
-        vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, *graphicsQueueFamilyIndex_ptr(), surface, &presentSupport);
+        VkBool32 presentSupport = 0;
+        vkGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, *graphicsQueueFamilyIndex_ptr(), ds->surface, &presentSupport);
         if (!presentSupport) {
             fprintf(stderr, "Vulkan graphics queue family doesn't support presenting to surface\n"); exit(1);
         }
@@ -199,18 +198,10 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
     uint32_t imageCount;
     VkSurfaceFormatKHR surfaceFormat;
     VkPresentModeKHR presentMode; {
-        vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, &capabilities);
+        vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, ds->surface, &capabilities);
 
         if (capabilities.currentExtent.width != UINT32_MAX) {
             extent = capabilities.currentExtent;
-        } else {
-            $[expr { $useGlfw ? {
-                glfwGetFramebufferSize(window, (int*) &extent.width, (int*) &extent.height);
-                if (capabilities.minImageExtent.width > extent.width) { extent.width = capabilities.minImageExtent.width; }
-                if (capabilities.maxImageExtent.width < extent.width) { extent.width = capabilities.maxImageExtent.width; }
-                if (capabilities.minImageExtent.height > extent.height) { extent.height = capabilities.minImageExtent.height; }
-                if (capabilities.maxImageExtent.height < extent.height) { extent.height = capabilities.maxImageExtent.height; }
-            } : {} }]
         }
 
         imageCount = capabilities.minImageCount + 1;
@@ -219,10 +210,10 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
         }
 
         uint32_t formatCount;
-        vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, &formatCount, NULL);
+        vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, ds->surface, &formatCount, NULL);
         VkSurfaceFormatKHR formats[formatCount];
         if (formatCount == 0) { fprintf(stderr, "No supported surface formats.\n"); exit(1); }
-        vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, &formatCount, formats);
+        vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, ds->surface, &formatCount, formats);
         surfaceFormat = formats[0]; // semi-arbitrary default
         for (int i = 0; i < formatCount; i++) {
             if (formats[i].format == VK_FORMAT_B8G8R8A8_UNORM) {
@@ -231,10 +222,10 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
         }
 
         uint32_t presentModeCount;
-        vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, &presentModeCount, NULL);
+        vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, ds->surface, &presentModeCount, NULL);
         VkPresentModeKHR presentModes[presentModeCount];
         if (presentModeCount == 0) { fprintf(stderr, "No supported present modes.\n"); exit(1); }
-        vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, &presentModeCount, presentModes);
+        vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, ds->surface, &presentModeCount, presentModes);
         presentMode = VK_PRESENT_MODE_FIFO_KHR; // guaranteed to be available
         for (int i = 0; i < presentModeCount; i++) {
             if (presentModes[i] == VK_PRESENT_MODE_MAILBOX_KHR) {
@@ -243,11 +234,11 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
         }
     }
 
-    // Set up VkSwapchainKHR swapchain
+    // Set up VkSwapchainKHR
     {
         VkSwapchainCreateInfoKHR createInfo = {0};
         createInfo.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
-        createInfo.surface = surface;
+        createInfo.surface = ds->surface;
 
         createInfo.minImageCount = imageCount;
         createInfo.imageFormat = surfaceFormat.format;
@@ -269,26 +260,24 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
         createInfo.clipped = VK_TRUE;
         createInfo.oldSwapchain = VK_NULL_HANDLE;
 
-        $[vktry {vkCreateSwapchainKHR(device, &createInfo, NULL, &swapchain)}]
+        $[vktry {vkCreateSwapchainKHR(device, &createInfo, NULL, &ds->swapchain)}]
     }
 
-    // Set up uint32_t swapchainImageCount:
-    vkGetSwapchainImagesKHR(device, swapchain, &swapchainImageCount, NULL);
-    VkImage swapchainImages[swapchainImageCount];
-    // Set up VkExtent2D swapchainExtent:
+    vkGetSwapchainImagesKHR(device, ds->swapchain, &ds->swapchainImageCount, NULL);
+    VkImage swapchainImages[ds->swapchainImageCount];
     {
-        vkGetSwapchainImagesKHR(device, swapchain, &swapchainImageCount, swapchainImages);
-        swapchainImageFormat = surfaceFormat.format;
-        swapchainExtent = extent;
+        vkGetSwapchainImagesKHR(device, ds->swapchain, &ds->swapchainImageCount, swapchainImages);
+        ds->swapchainImageFormat = surfaceFormat.format;
+        ds->swapchainExtent = extent;
     }
 
-    VkImageView swapchainImageViews[swapchainImageCount]; {
-        for (size_t i = 0; i < swapchainImageCount; i++) {
+    VkImageView swapchainImageViews[ds->swapchainImageCount]; {
+        for (size_t i = 0; i < ds->swapchainImageCount; i++) {
             VkImageViewCreateInfo createInfo = {0};
             createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
             createInfo.image = swapchainImages[i];
             createInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-            createInfo.format = swapchainImageFormat;
+            createInfo.format = ds->swapchainImageFormat;
             createInfo.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
             createInfo.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
             createInfo.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
@@ -302,13 +291,13 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
         }
     }
 
-    if (swapchainImageFormat != VK_FORMAT_B8G8R8A8_UNORM) {
-        FOLK_ERROR("Swapchain image format %d does not match pipeline render pass format (VK_FORMAT_B8G8R8A8_UNORM)\n", swapchainImageFormat);
+    if (ds->swapchainImageFormat != VK_FORMAT_B8G8R8A8_UNORM) {
+        FOLK_ERROR("Swapchain image format %d does not match pipeline render pass format (VK_FORMAT_B8G8R8A8_UNORM)\n", ds->swapchainImageFormat);
     }
 
-    // Set up VkFramebuffer swapchainFramebuffers[swapchainImageCount]:
-    swapchainFramebuffers = (VkFramebuffer *) malloc(sizeof(VkFramebuffer) * swapchainImageCount);
-    for (size_t i = 0; i < swapchainImageCount; i++) {
+    // Set up framebuffers
+    ds->swapchainFramebuffers = (VkFramebuffer *) malloc(sizeof(VkFramebuffer) * ds->swapchainImageCount);
+    for (size_t i = 0; i < ds->swapchainImageCount; i++) {
         VkImageView attachments[] = { swapchainImageViews[i] };
 
         VkFramebufferCreateInfo framebufferInfo = {0};
@@ -316,11 +305,11 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
         framebufferInfo.renderPass = *renderPass_ptr();
         framebufferInfo.attachmentCount = 1;
         framebufferInfo.pAttachments = attachments;
-        framebufferInfo.width = swapchainExtent.width;
-        framebufferInfo.height = swapchainExtent.height;
+        framebufferInfo.width = ds->swapchainExtent.width;
+        framebufferInfo.height = ds->swapchainExtent.height;
         framebufferInfo.layers = 1;
 
-        $[vktry {vkCreateFramebuffer(device, &framebufferInfo, NULL, &swapchainFramebuffers[i])}]
+        $[vktry {vkCreateFramebuffer(device, &framebufferInfo, NULL, &ds->swapchainFramebuffers[i])}]
     }
 
     {
@@ -331,24 +320,23 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
         fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
         fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
 
-        $[vktry {vkCreateSemaphore(device, &semaphoreInfo, NULL, &imageAvailableSemaphore)}]
-        $[vktry {vkCreateSemaphore(device, &semaphoreInfo, NULL, &renderFinishedSemaphore)}]
-        $[vktry {vkCreateFence(device, &fenceInfo, NULL, &inFlightFence)}]
+        $[vktry {vkCreateSemaphore(device, &semaphoreInfo, NULL, &ds->imageAvailableSemaphore)}]
+        $[vktry {vkCreateSemaphore(device, &semaphoreInfo, NULL, &ds->renderFinishedSemaphore)}]
+        $[vktry {vkCreateFence(device, &fenceInfo, NULL, &ds->inFlightFence)}]
     }
-}
-$cc proc getWidth {} uint32_t { return swapchainExtent.width; }
-$cc proc getHeight {} uint32_t { return swapchainExtent.height; }
 
-$cc code {
-    static VkPipeline boundPipeline;
-    static VkDescriptorSet boundDescriptorSet;
+    return ds;
 }
-$cc proc drawStart {} void {
+$cc proc getDisplayWidth {DisplayState* ds} uint32_t { return ds->swapchainExtent.width; }
+$cc proc getDisplayHeight {DisplayState* ds} uint32_t { return ds->swapchainExtent.height; }
+
+$cc proc drawStart {DisplayState* ds} void {
+    currentDisplay = ds;
     VkCommandBuffer commandBuffer = getCommandBuffer();
 
-    vkResetFences(device, 1, &inFlightFence);
+    vkResetFences(device, 1, &ds->inFlightFence);
 
-    vkAcquireNextImageKHR(device, swapchain, UINT64_MAX, imageAvailableSemaphore, VK_NULL_HANDLE, &imageIndex);
+    vkAcquireNextImageKHR(device, ds->swapchain, UINT64_MAX, ds->imageAvailableSemaphore, VK_NULL_HANDLE, &ds->imageIndex);
 
     vkResetCommandBuffer(commandBuffer, 0);
 
@@ -362,9 +350,9 @@ $cc proc drawStart {} void {
         VkRenderPassBeginInfo renderPassInfo = {0};
         renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
         renderPassInfo.renderPass = *renderPass_ptr();
-        renderPassInfo.framebuffer = swapchainFramebuffers[imageIndex];
+        renderPassInfo.framebuffer = ds->swapchainFramebuffers[ds->imageIndex];
         renderPassInfo.renderArea.offset = (VkOffset2D) {0, 0};
-        renderPassInfo.renderArea.extent = swapchainExtent;
+        renderPassInfo.renderArea.extent = ds->swapchainExtent;
 
         VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
         renderPassInfo.clearValueCount = 1;
@@ -390,15 +378,15 @@ $cc proc draw {Pipeline pipeline Jim_Obj* argsObj} void {
         VkViewport viewport = {0}; {
             viewport.x = 0.0f;
             viewport.y = 0.0f;
-            viewport.width = (float) swapchainExtent.width;
-            viewport.height = (float) swapchainExtent.height;
+            viewport.width = (float) currentDisplay->swapchainExtent.width;
+            viewport.height = (float) currentDisplay->swapchainExtent.height;
             viewport.minDepth = 0.0f;
             viewport.maxDepth = 1.0f;
         }
         vkCmdSetViewport(commandBuffer, 0, 1, &viewport);
         VkRect2D scissor = {0}; {
             scissor.offset = (VkOffset2D) {0, 0};
-            scissor.extent = swapchainExtent;
+            scissor.extent = currentDisplay->swapchainExtent;
         }
         vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
     }
@@ -429,17 +417,18 @@ $cc proc draw {Pipeline pipeline Jim_Obj* argsObj} void {
 }
 
 $cc proc drawEnd {} void {
+    DisplayState* ds = currentDisplay;
     VkCommandBuffer commandBuffer = getCommandBuffer();
 
     vkCmdEndRenderPass(commandBuffer);
     $[vktry {vkEndCommandBuffer(commandBuffer)}]
 
-    VkSemaphore signalSemaphores[] = {renderFinishedSemaphore};
+    VkSemaphore signalSemaphores[] = {ds->renderFinishedSemaphore};
     {
         VkSubmitInfo submitInfo = {0};
         submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
 
-        VkSemaphore waitSemaphores[] = {imageAvailableSemaphore};
+        VkSemaphore waitSemaphores[] = {ds->imageAvailableSemaphore};
         VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT};
         submitInfo.waitSemaphoreCount = 1;
         submitInfo.pWaitSemaphores = waitSemaphores;
@@ -452,7 +441,7 @@ $cc proc drawEnd {} void {
         submitInfo.pSignalSemaphores = signalSemaphores;
 
         pthread_mutex_lock(graphicsQueueMutex_ptr());
-        $[vktry {vkQueueSubmit(*graphicsQueue_ptr(), 1, &submitInfo, inFlightFence)}]
+        $[vktry {vkQueueSubmit(*graphicsQueue_ptr(), 1, &submitInfo, ds->inFlightFence)}]
         pthread_mutex_unlock(graphicsQueueMutex_ptr());
     }
     {
@@ -461,10 +450,10 @@ $cc proc drawEnd {} void {
         presentInfo.waitSemaphoreCount = 1;
         presentInfo.pWaitSemaphores = signalSemaphores;
 
-        VkSwapchainKHR swapchains[] = {swapchain};
+        VkSwapchainKHR swapchains[] = {ds->swapchain};
         presentInfo.swapchainCount = 1;
         presentInfo.pSwapchains = swapchains;
-        presentInfo.pImageIndices = &imageIndex;
+        presentInfo.pImageIndices = &ds->imageIndex;
         presentInfo.pResults = NULL;
 
         pthread_mutex_lock(graphicsQueueMutex_ptr());
@@ -472,11 +461,11 @@ $cc proc drawEnd {} void {
         pthread_mutex_unlock(graphicsQueueMutex_ptr());
     }
 
-    vkWaitForFences(device, 1, &inFlightFence, VK_TRUE, UINT64_MAX);
-}
+    // Wait for this display's submission to complete before we
+    // reuse the shared command buffer for the next display.
+    vkWaitForFences(device, 1, &ds->inFlightFence, VK_TRUE, UINT64_MAX);
 
-$cc proc poll {} void {
-    $[expr { $useGlfw ? { glfwPollEvents(); } : {} }]
+    currentDisplay = NULL;
 }
 
 proc makeGpu {gpuLib pipelineLib drawLib} { return [library create gpu {gpuLib pipelineLib drawLib} {
@@ -854,11 +843,8 @@ set gpu [makeGpu $gpuLib $pipelineLib $drawLib]
 
 tracy setThreadName "gpu"
 
-$gpu initDraw $display \
-    $displayOpts(width) $displayOpts(height) \
-    $displayOpts(refreshRate)
-
-Claim display $display has width [$gpu getWidth] height [$gpu getHeight]
+# Track initialized displays: dict mapping display name -> DisplayState*
+set displays [dict create]
 
 set kGpu [tracy makeString "gpu"]
 set kLatency [tracy makeString "latency"]
@@ -922,15 +908,12 @@ When /wisher/ wishes the GPU compiles pipeline /name/ /source/ {
 
 set missingPipelines [dict create]
 while true {
+    # Run prelude handlers once per frame (textures, canvases).
     ForEach! /someone/ wishes the GPU runs frame prelude handler /hd/ {
         {*}$hd
     }
 
-    $gpu drawStart
-
-    # We do the queries now (when we are about to draw) so we get
-    # the most up-to-date information.
-
+    # Query draw commands once (shared across all displays).
     set results [Query! /someone/ claims the GPU compiles pipeline /name/ to /pipeline/]
     set pipelines [dict create]
     foreach result $results { dict with result { dict set pipelines $name $pipeline } }
@@ -968,22 +951,39 @@ while true {
         }
     }
 
-    set drawCount 0
-    foreach layer [lsort -real [dict keys $displayList]] {
-        set layerDisplayList [dict get $displayList $layer]
-        foreach displayCommand $layerDisplayList {
-            incr drawCount
-            try { {*}$displayCommand } \
-                on error e { puts stderr [errorInfo $e] }
+    # Query active displays; init new ones on first sight.
+    foreach result [Query! /someone/ wishes $::thisNode uses display /display/ with /...displayOpts/] {
+        set display [dict get $result display]
+        set displayOpts [dict get $result displayOpts]
+
+        if {![dict exists $displays $display]} {
+            set ds [$drawLib initDisplay $display \
+                        $displayOpts(width) $displayOpts(height) \
+                        $displayOpts(refreshRate)]
+            dict set displays $display $ds
+            Assert! display $display has width [$drawLib getDisplayWidth $ds] \
+                height [$drawLib getDisplayHeight $ds]
         }
     }
 
-    # This blocks until the frame is actually drawn:
-    $gpu drawEnd
+    # Draw to each active display.
+    dict for {displayName ds} $displays {
+        $gpu drawStart $ds
+
+        set drawCount 0
+        foreach layer [lsort -real [dict keys $displayList]] {
+            set layerDisplayList [dict get $displayList $layer]
+            foreach displayCommand $layerDisplayList {
+                incr drawCount
+                try { {*}$displayCommand } \
+                    on error e { puts stderr [errorInfo $e] }
+            }
+        }
+
+        $gpu drawEnd
+    }
 
     tracy frameMarkNamed $kGpu
-
-    $gpu poll
 
     # TODO: sleep for 5ms or something?
 }

--- a/builtin-programs/gpu/draw.folk
+++ b/builtin-programs/gpu/draw.folk
@@ -135,16 +135,53 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
                        display, width, height, refreshRate);
         }
 
+        // Find a display plane that supports chosenDisplay.
+        // Lock so two display threads don't pick the same plane.
+        pthread_mutex_lock(displaySurfaceMutex_ptr());
+
+        uint32_t planeCount;
+        vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, &planeCount, NULL);
+        VkDisplayPlanePropertiesKHR planeProps[planeCount];
+        vkGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, &planeCount, planeProps);
+
+        uint32_t chosenPlane = UINT32_MAX;
+        for (uint32_t p = 0; p < planeCount; p++) {
+            // Skip planes already bound to a different display.
+            if (planeProps[p].currentDisplay != VK_NULL_HANDLE &&
+                planeProps[p].currentDisplay != chosenDisplay) {
+                continue;
+            }
+            // Check that this plane supports our display.
+            uint32_t supportedCount;
+            vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, p, &supportedCount, NULL);
+            VkDisplayKHR supported[supportedCount];
+            vkGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, p, &supportedCount, supported);
+            for (uint32_t s = 0; s < supportedCount; s++) {
+                if (supported[s] == chosenDisplay) {
+                    chosenPlane = p;
+                    break;
+                }
+            }
+            if (chosenPlane != UINT32_MAX) break;
+        }
+        if (chosenPlane == UINT32_MAX) {
+            pthread_mutex_unlock(displaySurfaceMutex_ptr());
+            FOLK_ERROR("Failed to find a display plane for display '%s'\n", display);
+        }
+
         VkDisplaySurfaceCreateInfoKHR createInfo = {0};
         createInfo.sType = VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR;
         createInfo.displayMode = modeProps[chosenMode].displayMode;
-        createInfo.planeIndex = 0;
+        createInfo.planeIndex = chosenPlane;
         createInfo.transform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
         createInfo.alphaMode = VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR;
         createInfo.imageExtent = modeProps[chosenMode].parameters.visibleRegion;
         if (vkCreateDisplayPlaneSurfaceKHR(*instance_ptr(), &createInfo, NULL, &surface) != VK_SUCCESS) {
+            pthread_mutex_unlock(displaySurfaceMutex_ptr());
             fprintf(stderr, "Failed to create Vulkan display plane surface\n"); exit(1);
         }
+
+        pthread_mutex_unlock(displaySurfaceMutex_ptr());
     }] }]
 
     uint32_t presentQueueFamilyIndex; {

--- a/builtin-programs/gpu/draw.folk
+++ b/builtin-programs/gpu/draw.folk
@@ -17,8 +17,7 @@ When the GPU library is /gpuLib/ &\
 fn defineVulkanHandleType
 
 # On macOS we always use GLFW; on Linux we use direct Vulkan display.
-# (On macOS, draw.folk returns early above, so this only runs on Linux.)
-set useGlfw false
+set useGlfw [expr {$::tcl_platform(os) eq "darwin"}]
 
 set cc [C]
 $cc cflags -I./vendor
@@ -28,6 +27,13 @@ $cc include <pthread.h>
 $cc code {
     #define VOLK_IMPLEMENTATION
     #include "volk/volk.h"
+}
+if {$useGlfw} {
+    $cc code {
+        // This must be included _after_ volk.h (Vulkan).
+        #include <GLFW/glfw3.h>
+    }
+    $cc endcflags -lglfw
 }
 
 $cc extend $gpuLib
@@ -41,7 +47,7 @@ local proc vktry {call} { string map {\n " "} [csubst {{
     }
 }}] }
 
-$cc code {
+$cc code [subst {
     typedef struct DisplayState {
         VkSurfaceKHR surface;
         VkSwapchainKHR swapchain;
@@ -55,6 +61,7 @@ $cc code {
         VkSemaphore imageAvailableSemaphore;
         VkSemaphore renderFinishedSemaphore;
         VkFence inFlightFence;
+        [expr { $useGlfw ? "GLFWwindow* window;" : "" }]
     } DisplayState;
 
     VkDevice device;
@@ -63,7 +70,7 @@ $cc code {
     static DisplayState* currentDisplay;
     static VkPipeline boundPipeline;
     static VkDescriptorSet boundDescriptorSet;
-}
+}]
 
 $cc argtype DisplayState* {
     DisplayState* $argname;
@@ -87,7 +94,14 @@ $cc proc initDisplay {char* display uint32_t width uint32_t height uint32_t refr
     DisplayState* ds = calloc(1, sizeof(DisplayState));
 
     // Get drawing surface.
-    $[csubst {
+    $[expr { $useGlfw ? {
+        glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+        ds->window = glfwCreateWindow(width, height, "Folk", NULL, NULL);
+        FOLK_ENSURE(ds->window != NULL);
+        if (glfwCreateWindowSurface(*instance_ptr(), ds->window, NULL, &ds->surface) != VK_SUCCESS) {
+            FOLK_ERROR("Failed to create GLFW window surface");
+        }
+    } : [csubst {
         // Search through displays to find the one matching display name
         int retries = 0;
         VkDisplayKHR chosenDisplay = VK_NULL_HANDLE;
@@ -181,7 +195,7 @@ $cc proc initDisplay {char* display uint32_t width uint32_t height uint32_t refr
         createInfo.alphaMode = VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR;
         createInfo.imageExtent = modeProps[chosenMode].parameters.visibleRegion;
         $[vktry {vkCreateDisplayPlaneSurfaceKHR(*instance_ptr(), &createInfo, NULL, &ds->surface)}]
-    }]
+    }] }]
 
     uint32_t presentQueueFamilyIndex; {
         VkBool32 presentSupport = 0;
@@ -202,6 +216,14 @@ $cc proc initDisplay {char* display uint32_t width uint32_t height uint32_t refr
 
         if (capabilities.currentExtent.width != UINT32_MAX) {
             extent = capabilities.currentExtent;
+        } else {
+            $[expr { $useGlfw ? {
+                glfwGetFramebufferSize(ds->window, (int*) &extent.width, (int*) &extent.height);
+                if (capabilities.minImageExtent.width > extent.width) { extent.width = capabilities.minImageExtent.width; }
+                if (capabilities.maxImageExtent.width < extent.width) { extent.width = capabilities.maxImageExtent.width; }
+                if (capabilities.minImageExtent.height > extent.height) { extent.height = capabilities.minImageExtent.height; }
+                if (capabilities.maxImageExtent.height < extent.height) { extent.height = capabilities.maxImageExtent.height; }
+            } : {} }]
         }
 
         imageCount = capabilities.minImageCount + 1;
@@ -466,6 +488,10 @@ $cc proc drawEnd {} void {
     vkWaitForFences(device, 1, &ds->inFlightFence, VK_TRUE, UINT64_MAX);
 
     currentDisplay = NULL;
+}
+
+$cc proc poll {} void {
+    $[expr { $useGlfw ? { glfwPollEvents(); } : {} }]
 }
 
 proc makeGpu {gpuLib pipelineLib drawLib} { return [library create gpu {gpuLib pipelineLib drawLib} {
@@ -985,6 +1011,7 @@ while true {
 
     tracy frameMarkNamed $kGpu
 
+    if {$useGlfw} { $drawLib poll }
     # TODO: sleep for 5ms or something?
 }
 

--- a/builtin-programs/gpu/draw.folk
+++ b/builtin-programs/gpu/draw.folk
@@ -11,6 +11,7 @@ if {[info exists this] && $::tcl_platform(os) eq "darwin"} {
 
 When the GPU library is /gpuLib/ &\
      the GPU Vulkan handle type definer is /defineVulkanHandleType/ &\
+     the GPU pipeline library is /pipelineLib/ &\
      /someone/ wishes $::thisNode uses display /display/ with /...displayOpts/ {
 
 fn defineVulkanHandleType
@@ -34,6 +35,7 @@ if {$useGlfw} {
 }
 
 $cc extend $gpuLib
+$cc extend $pipelineLib
 
 local proc vktry {call} { string map {\n " "} [csubst {{
     VkResult res = $call;
@@ -44,8 +46,6 @@ local proc vktry {call} { string map {\n " "} [csubst {{
 }}] }
 
 $cc define {
-    VkRenderPass renderPass;
-
     VkSwapchainKHR swapchain;
     uint32_t swapchainImageCount;
     VkFormat swapchainImageFormat;
@@ -62,36 +62,6 @@ $cc define {
 $cc code {
     VkDevice device;
     VkPhysicalDevice physicalDevice;
-
-    __thread VkCommandPool _commandPool;
-    __thread VkCommandBuffer _commandBuffer;
-}
-defineVulkanHandleType $cc VkCommandPool
-defineVulkanHandleType $cc VkCommandBuffer
-$cc proc getCommandPool {} VkCommandPool {
-    if (_commandPool == 0) {
-        VkCommandPoolCreateInfo poolInfo = {0};
-        poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-        poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-        poolInfo.queueFamilyIndex = *graphicsQueueFamilyIndex_ptr();
-
-        $[vktry {vkCreateCommandPool(device, &poolInfo, NULL, &_commandPool)}]
-    }
-    return _commandPool;
-}
-# Returns a thread-local command buffer. This assumes that you only
-# work on one command buffer at a time in a given thread.
-$cc proc getCommandBuffer {} VkCommandBuffer {
-    if (_commandBuffer == 0) {
-        VkCommandBufferAllocateInfo allocInfo = {0};
-        allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-        allocInfo.commandPool = getCommandPool();
-        allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-        allocInfo.commandBufferCount = 1;
-
-        $[vktry {vkAllocateCommandBuffers(device, &allocInfo, &_commandBuffer)}]
-    }
-    return _commandBuffer;
 }
 
 $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refreshRate} void {
@@ -218,7 +188,7 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
         vkGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, &formatCount, formats);
         surfaceFormat = formats[0]; // semi-arbitrary default
         for (int i = 0; i < formatCount; i++) {
-            if (formats[i].format == VK_FORMAT_B8G8R8A8_SRGB && formats[i].colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+            if (formats[i].format == VK_FORMAT_B8G8R8A8_UNORM) {
                 surfaceFormat = formats[i];
             }
         }
@@ -295,46 +265,8 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
         }
     }
 
-    // Set up VkRenderPass renderPass:
-    {
-        VkAttachmentDescription colorAttachment = {0};
-        colorAttachment.format = swapchainImageFormat;
-        colorAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
-        colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-        colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-        colorAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-        colorAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-        colorAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        colorAttachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-
-        VkAttachmentReference colorAttachmentRef = {0};
-        colorAttachmentRef.attachment = 0;
-        colorAttachmentRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-
-        VkSubpassDescription subpass = {0};
-        subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-        subpass.colorAttachmentCount = 1;
-        subpass.pColorAttachments = &colorAttachmentRef;
-
-        VkRenderPassCreateInfo renderPassInfo = {0};
-        renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-        renderPassInfo.attachmentCount = 1;
-        renderPassInfo.pAttachments = &colorAttachment;
-        renderPassInfo.subpassCount = 1;
-        renderPassInfo.pSubpasses = &subpass;
-
-        VkSubpassDependency dependency = {0};
-        dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
-        dependency.dstSubpass = 0;
-        dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-        dependency.srcAccessMask = 0;
-        dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-        dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-
-        renderPassInfo.dependencyCount = 1;
-        renderPassInfo.pDependencies = &dependency;
-
-        $[vktry {vkCreateRenderPass(device, &renderPassInfo, NULL, &renderPass)}]
+    if (swapchainImageFormat != VK_FORMAT_B8G8R8A8_UNORM) {
+        FOLK_ERROR("Swapchain image format %d does not match pipeline render pass format (VK_FORMAT_B8G8R8A8_UNORM)\n", swapchainImageFormat);
     }
 
     // Set up VkFramebuffer swapchainFramebuffers[swapchainImageCount]:
@@ -344,7 +276,7 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
 
         VkFramebufferCreateInfo framebufferInfo = {0};
         framebufferInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-        framebufferInfo.renderPass = renderPass;
+        framebufferInfo.renderPass = *renderPass_ptr();
         framebufferInfo.attachmentCount = 1;
         framebufferInfo.pAttachments = attachments;
         framebufferInfo.width = swapchainExtent.width;
@@ -370,209 +302,6 @@ $cc proc initDraw {char* display uint32_t width uint32_t height uint32_t refresh
 $cc proc getWidth {} uint32_t { return swapchainExtent.width; }
 $cc proc getHeight {} uint32_t { return swapchainExtent.height; }
 
-# Shader compilation:
-defineVulkanHandleType $cc VkShaderModule
-# createShaderModule takes a Tcl list of integers (the compiled shader
-# bytecode).
-$cc proc createShaderModule {Jim_Obj* codeObj} VkShaderModule {
-    int codeObjc = Jim_ListLength(interp, codeObj);
-    uint32_t* code = malloc(codeObjc * sizeof(uint32_t));
-    for (int i = 0; i < codeObjc; i++) {
-        Jim_Obj* codeObjv = Jim_ListGetIndex(interp, codeObj, i);
-        long val;
-        Jim_GetLong(interp, codeObjv, &val);
-        code[i] = (uint32_t)val;
-    }
-
-    VkShaderModuleCreateInfo createInfo = {0};
-    createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    createInfo.codeSize = codeObjc * sizeof(uint32_t);
-    createInfo.pCode = code;
-
-    VkShaderModule shaderModule;
-    $[vktry {vkCreateShaderModule(device, &createInfo, NULL, &shaderModule)}]
-    free(code);
-    return shaderModule;
-}
-
-# Pipeline creation:
-defineVulkanHandleType $cc VkPipeline
-defineVulkanHandleType $cc VkPipelineLayout
-defineVulkanHandleType $cc VkDescriptorSet
-defineVulkanHandleType $cc VkDescriptorSetLayout
-$cc typedef uint64_t VkDeviceSize
-$cc argtype VkDescriptorType { int $argname; __ENSURE_OK(Tcl_GetIntFromObj(interp, $obj, &$argname)); }
-$cc rtype VkDescriptorType { $robj = Tcl_NewIntObj($rvalue); }
-$cc code {
-    typedef struct PushConstantsEncoder {
-        int (*encode)(Jim_Interp* interp, Jim_Obj* obj, uint8_t out[128]);
-    } PushConstantsEncoder;
-}
-$cc define {
-    VkDescriptorSetLayout textureDescriptorSetLayout;
-    VkDescriptorSet textureDescriptorSet;
-}
-$cc struct Pipeline {
-    VkPipeline pipeline;
-    VkPipelineLayout pipelineLayout;
-
-    size_t pushConstantsSize;
-    PushConstantsEncoder* encodePushConstants;
-}
-$cc proc createPipeline {VkShaderModule vertShaderModule
-                           VkShaderModule fragShaderModule
-                           PushConstantsEncoder* encodePushConstants
-                           size_t pushConstantsSize} Pipeline {
-        VkPipelineShaderStageCreateInfo shaderStages[2]; {
-        VkPipelineShaderStageCreateInfo vertShaderStageInfo = {0};
-        vertShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        vertShaderStageInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
-        vertShaderStageInfo.module = vertShaderModule;
-        vertShaderStageInfo.pName = "main";
-
-        VkPipelineShaderStageCreateInfo fragShaderStageInfo = {0};
-        fragShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-        fragShaderStageInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-        fragShaderStageInfo.module = fragShaderModule;
-        fragShaderStageInfo.pName = "main";
-
-        shaderStages[0] = vertShaderStageInfo;
-        shaderStages[1] = fragShaderStageInfo;
-    }
-
-    VkPipelineVertexInputStateCreateInfo vertexInputInfo = {0}; {
-        vertexInputInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-        vertexInputInfo.vertexBindingDescriptionCount = 0;
-        vertexInputInfo.vertexAttributeDescriptionCount = 0;
-    }
-
-    VkPipelineInputAssemblyStateCreateInfo inputAssembly = {0}; {
-        inputAssembly.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-        inputAssembly.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
-        inputAssembly.primitiveRestartEnable = VK_FALSE;
-    }
-
-    VkViewport viewport = {0}; {
-        viewport.x = 0.0f;
-        viewport.y = 0.0f;
-        viewport.width = (float) swapchainExtent.width;
-        viewport.height = (float) swapchainExtent.height;
-        viewport.minDepth = 0.0f;
-        viewport.maxDepth = 1.0f;
-    }
-    VkRect2D scissor = {0}; {
-        scissor.offset = (VkOffset2D) {0, 0};
-        scissor.extent = swapchainExtent;
-    }
-    VkPipelineViewportStateCreateInfo viewportState = {0};
-    viewportState.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
-    viewportState.viewportCount = 1;
-    viewportState.pViewports = &viewport;
-    viewportState.scissorCount = 1;
-    viewportState.pScissors = &scissor;
-
-    VkPipelineRasterizationStateCreateInfo rasterizer = {0};
-    rasterizer.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
-    rasterizer.depthClampEnable = VK_FALSE;
-    rasterizer.rasterizerDiscardEnable = VK_FALSE;
-    rasterizer.polygonMode = VK_POLYGON_MODE_FILL;
-    rasterizer.lineWidth = 1.0f;
-    rasterizer.cullMode = VK_CULL_MODE_BACK_BIT;
-    rasterizer.frontFace = VK_FRONT_FACE_CLOCKWISE;
-    rasterizer.depthBiasEnable = VK_FALSE;
-
-    VkPipelineMultisampleStateCreateInfo multisampling = {0};
-    multisampling.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-    multisampling.sampleShadingEnable = VK_FALSE;
-    multisampling.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-
-    VkPipelineColorBlendAttachmentState colorBlendAttachment = {0};
-    colorBlendAttachment.colorWriteMask =
-      VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT |
-      VK_COLOR_COMPONENT_A_BIT;
-    colorBlendAttachment.blendEnable = VK_TRUE;
-    colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
-    colorBlendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
-    colorBlendAttachment.colorBlendOp = VK_BLEND_OP_ADD;
-    colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
-    colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
-    colorBlendAttachment.alphaBlendOp = VK_BLEND_OP_ADD;
-
-    VkPipelineColorBlendStateCreateInfo colorBlending = {0};
-    colorBlending.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-    colorBlending.logicOpEnable = VK_FALSE;
-    colorBlending.logicOp = VK_LOGIC_OP_COPY; // Optional
-    colorBlending.attachmentCount = 1;
-    colorBlending.pAttachments = &colorBlendAttachment;
-
-    VkPipelineDynamicStateCreateInfo dynamicState = {0};
-    dynamicState.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
-    dynamicState.dynamicStateCount = 2;
-    // We need these to be dynamic so that pipelines can be retargeted
-    // to drawable surfaces (which have different viewports & scissors
-    // than the whole screen does).
-    VkDynamicState dynamicStates[] = {
-        VK_DYNAMIC_STATE_VIEWPORT,
-        VK_DYNAMIC_STATE_SCISSOR
-    };
-    dynamicState.pDynamicStates = dynamicStates;
-
-    VkPipelineLayout pipelineLayout; {
-        VkPipelineLayoutCreateInfo pipelineLayoutInfo = {0};
-        pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-
-        pipelineLayoutInfo.pSetLayouts = &textureDescriptorSetLayout;
-        pipelineLayoutInfo.setLayoutCount = 1;
-
-        // We configure all pipelines with push constants size =
-        // 128 (the maximum), no matter what actual push constants
-        // they take; this is so that pipelines are all
-        // layout-compatible so we can reuse descriptor set
-        // between pipelines without needing to rebind it.
-        VkPushConstantRange pushConstantRange = {0};
-        pushConstantRange.offset = 0;
-        pushConstantRange.size = 128;
-        pushConstantRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-
-        pipelineLayoutInfo.pPushConstantRanges = &pushConstantRange;
-        pipelineLayoutInfo.pushConstantRangeCount = 1;
-
-        $[vktry {vkCreatePipelineLayout(device, &pipelineLayoutInfo, NULL, &pipelineLayout)}]
-    }
-
-    VkPipeline pipeline; {
-        VkGraphicsPipelineCreateInfo pipelineInfo = {0};
-        pipelineInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-        pipelineInfo.stageCount = 2;
-        pipelineInfo.pStages = shaderStages;
-        pipelineInfo.pVertexInputState = &vertexInputInfo;
-        pipelineInfo.pInputAssemblyState = &inputAssembly;
-        pipelineInfo.pViewportState = &viewportState;
-        pipelineInfo.pRasterizationState = &rasterizer;
-        pipelineInfo.pMultisampleState = &multisampling;
-        pipelineInfo.pDepthStencilState = NULL;
-        pipelineInfo.pColorBlendState = &colorBlending;
-        pipelineInfo.pDynamicState = &dynamicState;
-
-        pipelineInfo.layout = pipelineLayout;
-
-        pipelineInfo.renderPass = renderPass;
-        pipelineInfo.subpass = 0;
-
-        pipelineInfo.basePipelineHandle = VK_NULL_HANDLE;
-        pipelineInfo.basePipelineIndex = -1;
-
-        $[vktry {vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, NULL, &pipeline)}]
-    }
-
-    return (Pipeline) {
-        .pipeline = pipeline,
-        .pipelineLayout = pipelineLayout,
-        .pushConstantsSize = pushConstantsSize,
-        .encodePushConstants = encodePushConstants
-    };
-}
-    
 $cc code {
     static VkPipeline boundPipeline;
     static VkDescriptorSet boundDescriptorSet;
@@ -595,7 +324,7 @@ $cc proc drawStart {} void {
     {
         VkRenderPassBeginInfo renderPassInfo = {0};
         renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-        renderPassInfo.renderPass = renderPass;
+        renderPassInfo.renderPass = *renderPass_ptr();
         renderPassInfo.framebuffer = swapchainFramebuffers[imageIndex];
         renderPassInfo.renderArea.offset = (VkOffset2D) {0, 0};
         renderPassInfo.renderArea.extent = swapchainExtent;
@@ -637,10 +366,10 @@ $cc proc draw {Pipeline pipeline Jim_Obj* argsObj} void {
         vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
     }
 
-    if (boundDescriptorSet != textureDescriptorSet) {
-        vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                pipeline.pipelineLayout, 0, 1, &textureDescriptorSet, 0, NULL);
-        boundDescriptorSet = textureDescriptorSet;
+    VkDescriptorSet currentDescriptorSet = getTextureDescriptorSet();
+    if (boundDescriptorSet != currentDescriptorSet) {
+        bindTextureDescriptorSet(commandBuffer, pipeline.pipelineLayout);
+        boundDescriptorSet = currentDescriptorSet;
     }
 
     {
@@ -713,8 +442,9 @@ $cc proc poll {} void {
     $[expr { $useGlfw ? { glfwPollEvents(); } : {} }]
 }
 
-proc makeGpu {gpuLib drawLib} { return [library create gpu {gpuLib drawLib} {
+proc makeGpu {gpuLib pipelineLib drawLib} { return [library create gpu {gpuLib pipelineLib drawLib} {
     variable gpuLib
+    variable pipelineLib
     variable drawLib
 
     if {![exists -command $drawLib]} {
@@ -758,6 +488,7 @@ proc makeGpu {gpuLib drawLib} { return [library create gpu {gpuLib drawLib} {
     # screen.
     proc pipeline {fnDict args} {
         variable gpuLib
+        variable pipelineLib
         variable drawLib
 
         if {[llength $args] == 3} {
@@ -925,10 +656,10 @@ proc makeGpu {gpuLib drawLib} { return [library create gpu {gpuLib drawLib} {
             encoder->encode = encodeObj;
             return encoder;
         }
-        set pipelineLib [$cc compile]
+        set encoderLib [$cc compile]
 
-        set encodePushConstants [$pipelineLib makeEncoder]
-        set pushConstantsSize [$pipelineLib getArgsSize]
+        set encodePushConstants [$encoderLib makeEncoder]
+        set pushConstantsSize [$encoderLib getArgsSize]
 
         set pushConstantsCode [if {[llength $pushConstants] > 0} {
             subst {
@@ -945,7 +676,7 @@ proc makeGpu {gpuLib drawLib} { return [library create gpu {gpuLib drawLib} {
             }
         }]
 
-        set vertShaderModule [$drawLib createShaderModule [glslc -fshader-stage=vert [csubst {
+        set vertShaderModule [$pipelineLib createShaderModule [glslc -fshader-stage=vert [csubst {
             #version 450
 
             $pushConstantsCode
@@ -990,7 +721,7 @@ proc makeGpu {gpuLib drawLib} { return [library create gpu {gpuLib drawLib} {
         # possible value of the push constant and uses the right
         # statically-indexed descriptor.
         set gpuSupportsDynamicIndexing [$gpuLib getDoesSupportShaderSampledImageArrayDynamicIndexing]
-        set fragShaderModule [$drawLib createShaderModule [glslc -fshader-stage=frag [csubst {
+        set fragShaderModule [$pipelineLib createShaderModule [glslc -fshader-stage=frag [csubst {
             #version 450
 
             layout(set = 0, binding = 0) uniform sampler2D _samplers[$[$gpuLib getMaxTextures]];
@@ -1063,7 +794,7 @@ proc makeGpu {gpuLib drawLib} { return [library create gpu {gpuLib drawLib} {
 
         # pipeline needs to contain a specification of push constants,
         # so they can be filled in at draw time.
-        set pipeline [$drawLib createPipeline \
+        set pipeline [$pipelineLib createPipeline \
                           $vertShaderModule $fragShaderModule \
                           $encodePushConstants \
                           $pushConstantsSize]
@@ -1082,150 +813,142 @@ proc makeGpu {gpuLib drawLib} { return [library create gpu {gpuLib drawLib} {
 set drawLib [$cc compile]
 Claim the GPU draw library is $drawLib
 
-set gpu [makeGpu $gpuLib $drawLib]
+set gpu [makeGpu $gpuLib $pipelineLib $drawLib]
 
-When the GPU texture library for $drawLib is /gpuTextureLib/ {
-    tracy setThreadName "gpu"
+tracy setThreadName "gpu"
 
-    $gpu initDraw $display \
-        $displayOpts(width) $displayOpts(height) \
-        $displayOpts(refreshRate)
+$gpu initDraw $display \
+    $displayOpts(width) $displayOpts(height) \
+    $displayOpts(refreshRate)
 
-    $gpuTextureLib textureManagerInit
+Claim display $display has width [$gpu getWidth] height [$gpu getHeight]
 
-    Claim display $display has width [$gpu getWidth] height [$gpu getHeight]
+set kGpu [tracy makeString "gpu"]
+set kLatency [tracy makeString "latency"]
+set kQuadCount [tracy makeString "quadCount"]
+set kRegionCount [tracy makeString "regionCount"]
+set kDrawCount [tracy makeString "drawCount"]
 
-    set kGpu [tracy makeString "gpu"]
-    set kLatency [tracy makeString "latency"]
-    set kQuadCount [tracy makeString "quadCount"]
-    set kRegionCount [tracy makeString "regionCount"]
-    set kDrawCount [tracy makeString "drawCount"]
-
-    fn QueryAllFns! {} {
-        set fns [dict create]
-        ForEach! /someone/ claims the GPU compiles function /name/ to /fn/ {
-            dict set fns $name $fn
-        }
-        return $fns
+fn QueryAllFns! {} {
+    set fns [dict create]
+    ForEach! /someone/ claims the GPU compiles function /name/ to /fn/ {
+        dict set fns $name $fn
     }
-    fn tryCompileFn {wisher name source} {
+    return $fns
+}
+fn tryCompileFn {wisher name source} {
+    try {
+        set fns [QueryAllFns!]
+        set fn [$gpu fn $fns {*}$source]
+
+        # Technically a misnomer: the function is just stored, not
+        # compiled until it's been inlined into a shader.
+        Claim the GPU compiles function $name to $fn
+
+    } on 99 notFoundName {
+        puts "gpu fn $name: Waiting for $notFoundName"
+        When the GPU compiles function $notFoundName to /anything/ {
+            puts "Did compile $notFoundName"
+            tryCompileFn $wisher $name $source
+        }
+    } on error e {
+        puts stderr "Error: GPU compiles function $name: [errorInfo $e]"
+        Claim $wisher has error $e with info [errorInfo $e]
+    }
+}
+fn tryCompilePipeline {wisher name source} {
+    try {
+        set fns [QueryAllFns!]
+        set pipeline [$gpu pipeline $fns {*}$source]
+
+        puts "gpu: tryCompilePipeline: Compiled $name"
+        Claim the GPU compiles pipeline $name to $pipeline
+
+    } on 99 notFoundName {
+        puts "gpu pipeline $name: Waiting for $notFoundName"
+        When the GPU compiles function $notFoundName to /anything/ {
+            puts "Did compile $notFoundName"
+            tryCompilePipeline $wisher $name $source
+        }
+    } on error e {
+        puts stderr "Error: GPU compiles pipeline $name: [errorInfo $e]"
+        Claim $wisher has error $e with info [errorInfo $e]
+    }
+}
+
+When /wisher/ wishes the GPU compiles function /name/ /source/ {
+    tryCompileFn $wisher $name $source
+}
+When /wisher/ wishes the GPU compiles pipeline /name/ /source/ {
+    tryCompilePipeline $wisher $name $source
+}
+
+set missingPipelines [dict create]
+while true {
+    ForEach! /someone/ wishes the GPU runs frame prelude handler /hd/ {
+        {*}$hd
+    }
+
+    $gpu drawStart
+
+    # We do the queries now (when we are about to draw) so we get
+    # the most up-to-date information.
+
+    set results [Query! /someone/ claims the GPU compiles pipeline /name/ to /pipeline/]
+    set pipelines [dict create]
+    foreach result $results { dict with result { dict set pipelines $name $pipeline } }
+
+    set displayList [dict create]
+    foreach result [Query! /wisher/ wishes the GPU draws pipeline /name/ with /...options/] {
         try {
-            set fns [QueryAllFns!]
-            set fn [$gpu fn $fns {*}$source]
+            set name [dict get $result name]
+            if {![dict exists $pipelines $name]} {
+                if {![dict exists $missingPipelines $name]} {
+                    puts stderr "gpu: Missing pipeline $name"
+                    dict set missingPipelines $name true
+                }
+                continue
+            }
+            dict unset missingPipelines $name
 
-            # Technically a misnomer: the function is just stored, not
-            # compiled until it's been inlined into a shader.
-            Claim the GPU compiles function $name to $fn
+            set pipeline [dict get $pipelines [dict get $result name]]
 
-        } on 99 notFoundName {
-            puts "gpu fn $name: Waiting for $notFoundName"
-            When the GPU compiles function $notFoundName to /anything/ {
-                puts "Did compile $notFoundName"
-                tryCompileFn $wisher $name $source
+            set options [dict get $result options]
+            set layer [dict getdef $options layer 0]
+            if {[dict exists $options instances]} {
+                set instances [dict get $options instances]
+            } else {
+                set instances [list [dict get $options arguments]]
+            }
+            foreach instance $instances {
+                dict lappend displayList $layer \
+                    [list $gpu draw $pipeline $instance]
             }
         } on error e {
-            puts stderr "Error: GPU compiles function $name: [errorInfo $e]"
-            Claim $wisher has error $e with info [errorInfo $e]
-        }
-    }
-    fn tryCompilePipeline {wisher name source} {
-        try {
-            set fns [QueryAllFns!]
-            set pipeline [$gpu pipeline $fns {*}$source]
-
-            puts "gpu: tryCompilePipeline: Compiled $name"
-            Claim the GPU compiles pipeline $name to $pipeline
-
-        } on 99 notFoundName {
-            puts "gpu pipeline $name: Waiting for $notFoundName"
-            When the GPU compiles function $notFoundName to /anything/ {
-                puts "Did compile $notFoundName"
-                tryCompilePipeline $wisher $name $source
-            }
-        } on error e {
-            puts stderr "Error: GPU compiles pipeline $name: [errorInfo $e]"
-            Claim $wisher has error $e with info [errorInfo $e]
+            puts stderr "Error: GPU draws pipeline $name: [errorInfo $e]"
+            Assert! $this claims [dict get $result wisher] has error $e with info [errorInfo $e]
+            # TODO: does this ever get disposed?
         }
     }
 
-    When /wisher/ wishes the GPU compiles function /name/ /source/ {
-        tryCompileFn $wisher $name $source
-    }
-    When /wisher/ wishes the GPU compiles pipeline /name/ /source/ {
-        tryCompilePipeline $wisher $name $source
-    }
-
-    set missingPipelines [dict create]
-    while true {
-        ForEach! /someone/ wishes the GPU runs frame prelude handler /hd/ {
-            {*}$hd
+    set drawCount 0
+    foreach layer [lsort -real [dict keys $displayList]] {
+        set layerDisplayList [dict get $displayList $layer]
+        foreach displayCommand $layerDisplayList {
+            incr drawCount
+            try { {*}$displayCommand } \
+                on error e { puts stderr [errorInfo $e] }
         }
-
-        $gpu drawStart
-
-        # We do the queries now (when we are about to draw) so we get
-        # the most up-to-date information.
-
-        set results [Query! /someone/ claims the GPU compiles pipeline /name/ to /pipeline/]
-        set pipelines [dict create]
-        foreach result $results { dict with result { dict set pipelines $name $pipeline } }
-
-        set displayList [dict create]
-        foreach result [Query! /wisher/ wishes the GPU draws pipeline /name/ with /...options/] {
-            try {
-                set name [dict get $result name]
-                if {![dict exists $pipelines $name]} {
-                    if {![dict exists $missingPipelines $name]} {
-                        puts stderr "gpu: Missing pipeline $name"
-                        dict set missingPipelines $name true
-                    }
-                    continue
-                }
-                dict unset missingPipelines $name
-
-                set pipeline [dict get $pipelines [dict get $result name]]
-
-                set options [dict get $result options]
-                set layer [dict getdef $options layer 0]
-                if {[dict exists $options instances]} {
-                    set instances [dict get $options instances]
-                } else {
-                    set instances [list [dict get $options arguments]]
-                }
-                foreach instance $instances {
-                    dict lappend displayList $layer \
-                        [list $gpu draw $pipeline $instance]
-                }
-            } on error e {
-                puts stderr "Error: GPU draws pipeline $name: [errorInfo $e]"
-                Assert! $this claims [dict get $result wisher] has error $e with info [errorInfo $e]
-                # TODO: does this ever get disposed?
-            }
-        }
-
-        set drawCount 0
-        foreach layer [lsort -real [dict keys $displayList]] {
-            set layerDisplayList [dict get $displayList $layer]
-            foreach displayCommand $layerDisplayList {
-                incr drawCount
-                try { {*}$displayCommand } \
-                    on error e { puts stderr [errorInfo $e] }
-            }
-        }
-
-        # tracy plot $kQuadCount [llength [Query! /someone/ claims /tag/ has quad /q/]]
-        # tracy plot $kRegionCount [llength [Query! /someone/ claims {editing 785 /dev/input/by-path/pci-0000:02:00.0-usb-0:2:1.2-event-mouse} has region /r/]]
-        # tracy plot $kDrawCount $drawCount
-
-        # This blocks until the frame is actually drawn:
-        $gpu drawEnd
-
-        tracy frameMarkNamed $kGpu
-
-        $gpu poll
-
-        # TODO: sleep for 5ms or something?
     }
+
+    # This blocks until the frame is actually drawn:
+    $gpu drawEnd
+
+    tracy frameMarkNamed $kGpu
+
+    $gpu poll
+
+    # TODO: sleep for 5ms or something?
 }
 
 }

--- a/builtin-programs/gpu/draw.folk
+++ b/builtin-programs/gpu/draw.folk
@@ -983,17 +983,27 @@ while true {
         set displayOpts [dict get $result displayOpts]
 
         if {![dict exists $displays $display]} {
+            if {[llength [Query! $::thisNode has display $display with /...any/]] == 0} {
+                puts stderr "gpu/draw: Display '$display' is wished but not enumerated; skipping"
+                dict set displays $display missing
+                continue
+            }
             set ds [$drawLib initDisplay $display \
                         $displayOpts(width) $displayOpts(height) \
                         $displayOpts(refreshRate)]
             dict set displays $display $ds
             Assert! display $display has width [$drawLib getDisplayWidth $ds] \
                 height [$drawLib getDisplayHeight $ds]
+
+        } elseif {[dict get $displays $display] eq "missing"} {
+            # TODO: Allow for retry if display is plugged in later?
+            continue
         }
     }
 
     # Draw to each active display.
     dict for {displayName ds} $displays {
+        if {$ds eq "missing"} { continue }
         $gpu drawStart $ds
 
         set drawCount 0

--- a/builtin-programs/gpu/gpu.folk
+++ b/builtin-programs/gpu/gpu.folk
@@ -296,10 +296,16 @@ fn gpuInit {useGlfw} {
     set gpuLib [$gpuc compile]
 
     $gpuLib init $useGlfw
+
     Claim the GPU library is $gpuLib
 
     Claim the GPU physical device is [$gpuLib getPhysicalDevice]
     Claim the GPU device is [$gpuLib getDevice]
+}
+
+if {$::tcl_platform(os) eq "darwin"} {
+    gpuInit true
+    return
 }
 
 When $::thisNode has had displays enumerated {

--- a/builtin-programs/gpu/gpu.folk
+++ b/builtin-programs/gpu/gpu.folk
@@ -31,151 +31,79 @@ fn defineVulkanHandleType {cc type} {
 }
 Claim the GPU Vulkan handle type definer is [fn defineVulkanHandleType]
 
-When $::thisNode has had displays enumerated &\
-     /someone/ wishes $::thisNode uses display /display/ with /...any/ {
-
-set useGlfw $($display eq "glfw")
-
-# First, we build the C GPU library, which can make direct calls into
-# Vulkan -- this library then exposes functions that we can call from
-# Tcl.
-set gpuc [C]
-$gpuc cflags -I./vendor
-$gpuc include <pthread.h>
-$gpuc code {
-    #define VOLK_IMPLEMENTATION
-    #include "volk/volk.h"
-}
-if {$useGlfw} {
+fn gpuInit {useGlfw} {
+    # First, we build the C GPU library, which can make direct calls into
+    # Vulkan -- this library then exposes functions that we can call from
+    # Tcl.
+    set gpuc [C]
+    $gpuc cflags -I./vendor
+    $gpuc include <pthread.h>
     $gpuc code {
-        // This must be included _after_ volk.h (Vulkan).
-        #include <GLFW/glfw3.h>
+        #define VOLK_IMPLEMENTATION
+        #include "volk/volk.h"
     }
-}
-
-set macos [expr {$::tcl_platform(os) eq "darwin"}]
-if {$macos} {
-    $gpuc cflags -I/opt/homebrew/include -L/opt/homebrew/lib
-}
-
-if {$useGlfw} {
-    $gpuc endcflags -lglfw
-} else {
-    foreach renderFile [glob -nocomplain "/dev/dri/render*"] {
-        if {![file readable $renderFile]} {
-            puts stderr "Gpu: Warning: $renderFile is not readable by current user; Vulkan device may not appear.
-Try doing `sudo chmod 666 $renderFile`."
+    if {$useGlfw} {
+        $gpuc code {
+            // This must be included _after_ volk.h (Vulkan).
+            #include <GLFW/glfw3.h>
         }
     }
-}
 
-$gpuc argtype VkResult { long $argname; __ENSURE_OK(Jim_GetLong(interp, $obj, &$argname)); }
-$gpuc proc VkResultToString {VkResult res} char* {
-            switch (res) {
-    #define CASE(x) case VK_##x: return #x;
-            CASE(SUCCESS)                       CASE(NOT_READY)
-            CASE(TIMEOUT)                       CASE(EVENT_SET)
-            CASE(EVENT_RESET)                   CASE(INCOMPLETE)
-            CASE(ERROR_OUT_OF_HOST_MEMORY)      CASE(ERROR_OUT_OF_DEVICE_MEMORY)
-            CASE(ERROR_INITIALIZATION_FAILED)   CASE(ERROR_DEVICE_LOST)
-            CASE(ERROR_MEMORY_MAP_FAILED)       CASE(ERROR_LAYER_NOT_PRESENT)
-            CASE(ERROR_EXTENSION_NOT_PRESENT)   CASE(ERROR_FEATURE_NOT_PRESENT)
-            CASE(ERROR_INCOMPATIBLE_DRIVER)     CASE(ERROR_TOO_MANY_OBJECTS)
-            CASE(ERROR_FORMAT_NOT_SUPPORTED)    CASE(ERROR_FRAGMENTED_POOL)
-            CASE(ERROR_UNKNOWN)                 CASE(ERROR_OUT_OF_POOL_MEMORY)
-            CASE(ERROR_INVALID_EXTERNAL_HANDLE) CASE(ERROR_FRAGMENTATION)
-            CASE(ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS)
-            CASE(PIPELINE_COMPILE_REQUIRED)      CASE(ERROR_SURFACE_LOST_KHR)
-            CASE(ERROR_NATIVE_WINDOW_IN_USE_KHR) CASE(SUBOPTIMAL_KHR)
-            CASE(ERROR_OUT_OF_DATE_KHR)          CASE(ERROR_INCOMPATIBLE_DISPLAY_KHR)
-            CASE(ERROR_VALIDATION_FAILED_EXT)    CASE(ERROR_INVALID_SHADER_NV)
-    #ifdef VK_ENABLE_BETA_EXTENSIONS
-            CASE(ERROR_IMAGE_USAGE_NOT_SUPPORTED_KHR)
-            CASE(ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR)
-            CASE(ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR)
-            CASE(ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR)
-            CASE(ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR)
-            CASE(ERROR_VIDEO_STD_VERSION_NOT_SUPPORTED_KHR)
-    #endif
-            CASE(ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT)
-            CASE(ERROR_NOT_PERMITTED_KHR)
-            CASE(ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)
-            CASE(THREAD_IDLE_KHR)        CASE(THREAD_DONE_KHR)
-            CASE(OPERATION_DEFERRED_KHR) CASE(OPERATION_NOT_DEFERRED_KHR)
-            default: return "unknown";
-            }
-    #undef CASE
-}
-local proc vktry {call} { string map {\n " "} [csubst {{
-    VkResult res = $call;
-    if (res != VK_SUCCESS) {
-        fprintf(stderr, "Failed $call: %s (%d)\n",
-                VkResultToString(res), res); exit(1);
+    set macos [expr {$::tcl_platform(os) eq "darwin"}]
+    if {$macos} {
+        $gpuc cflags -I/opt/homebrew/include -L/opt/homebrew/lib
     }
-}}] }
 
-$gpuc define {
-    VkInstance instance;
-    VkPhysicalDevice physicalDevice;
-    VkPhysicalDeviceFeatures physicalDeviceFeatures;
-    VkPhysicalDeviceProperties physicalDeviceProperties;
+    if {$useGlfw} {
+        $gpuc endcflags -lglfw
+    } else {
+        foreach renderFile [glob -nocomplain "/dev/dri/render*"] {
+            if {![file readable $renderFile]} {
+                puts stderr "Gpu: Warning: $renderFile is not readable by current user; Vulkan device may not appear.
+    Try doing `sudo chmod 666 $renderFile`."
+            }
+        }
+    }
 
-    VkDevice device;
-    uint32_t computeQueueFamilyIndex;
-    uint32_t graphicsQueueFamilyIndex = UINT32_MAX;
-
-    pthread_mutex_t graphicsQueueMutex;
-    VkQueue graphicsQueue;
-    VkQueue presentQueue;
-    VkQueue computeQueue;
-}
-defineVulkanHandleType $gpuc VkPhysicalDevice
-defineVulkanHandleType $gpuc VkDevice
-$gpuc proc getPhysicalDevice {} VkPhysicalDevice { return physicalDevice; }
-$gpuc proc getDevice {} VkDevice { return device; }
-
-$gpuc proc init {bool useGlfw} void {
-    $[vktry volkInitialize()]
-    $[if {$useGlfw} { expr {"glfwInit();"} }]
-
-    // Set up VkInstance instance:
-    {
-        VkInstanceCreateInfo createInfo = {0};
-        createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-
-        const char* validationLayers[] = {
-           "VK_LAYER_KHRONOS_validation"
-        };
-        createInfo.enabledLayerCount = sizeof(validationLayers)/sizeof(validationLayers[0]);
-        createInfo.ppEnabledLayerNames = validationLayers;
-
-        $[if {$macos} {subst -nocommands {
-            const char* enabledExtensions[] = {
-                VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME,
-                VK_KHR_SURFACE_EXTENSION_NAME,
-                "VK_EXT_metal_surface",
-                VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
-            };
-            createInfo.enabledExtensionCount = sizeof(enabledExtensions)/sizeof(enabledExtensions[0]);
-
-        }} elseif {$useGlfw} {subst -nocommands {
-            const char** enabledExtensions = glfwGetRequiredInstanceExtensions(&createInfo.enabledExtensionCount);
-
-        }} else {subst -nocommands {
-            const char* enabledExtensions[] = {
-                // 2 extensions for non-X11/Wayland display
-                VK_KHR_SURFACE_EXTENSION_NAME,
-                VK_KHR_DISPLAY_EXTENSION_NAME,
-                VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
-            };
-            createInfo.enabledExtensionCount = sizeof(enabledExtensions)/sizeof(enabledExtensions[0]);
-        }}]
-        createInfo.ppEnabledExtensionNames = enabledExtensions;
-
-        $[if {$macos} { expr {{
-            createInfo.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
-        }} }]
-        VkResult res = vkCreateInstance(&createInfo, NULL, &instance);
+    $gpuc argtype VkResult { long $argname; __ENSURE_OK(Jim_GetLong(interp, $obj, &$argname)); }
+    $gpuc proc VkResultToString {VkResult res} char* {
+                switch (res) {
+        #define CASE(x) case VK_##x: return #x;
+                CASE(SUCCESS)                       CASE(NOT_READY)
+                CASE(TIMEOUT)                       CASE(EVENT_SET)
+                CASE(EVENT_RESET)                   CASE(INCOMPLETE)
+                CASE(ERROR_OUT_OF_HOST_MEMORY)      CASE(ERROR_OUT_OF_DEVICE_MEMORY)
+                CASE(ERROR_INITIALIZATION_FAILED)   CASE(ERROR_DEVICE_LOST)
+                CASE(ERROR_MEMORY_MAP_FAILED)       CASE(ERROR_LAYER_NOT_PRESENT)
+                CASE(ERROR_EXTENSION_NOT_PRESENT)   CASE(ERROR_FEATURE_NOT_PRESENT)
+                CASE(ERROR_INCOMPATIBLE_DRIVER)     CASE(ERROR_TOO_MANY_OBJECTS)
+                CASE(ERROR_FORMAT_NOT_SUPPORTED)    CASE(ERROR_FRAGMENTED_POOL)
+                CASE(ERROR_UNKNOWN)                 CASE(ERROR_OUT_OF_POOL_MEMORY)
+                CASE(ERROR_INVALID_EXTERNAL_HANDLE) CASE(ERROR_FRAGMENTATION)
+                CASE(ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS)
+                CASE(PIPELINE_COMPILE_REQUIRED)      CASE(ERROR_SURFACE_LOST_KHR)
+                CASE(ERROR_NATIVE_WINDOW_IN_USE_KHR) CASE(SUBOPTIMAL_KHR)
+                CASE(ERROR_OUT_OF_DATE_KHR)          CASE(ERROR_INCOMPATIBLE_DISPLAY_KHR)
+                CASE(ERROR_VALIDATION_FAILED_EXT)    CASE(ERROR_INVALID_SHADER_NV)
+        #ifdef VK_ENABLE_BETA_EXTENSIONS
+                CASE(ERROR_IMAGE_USAGE_NOT_SUPPORTED_KHR)
+                CASE(ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR)
+                CASE(ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR)
+                CASE(ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR)
+                CASE(ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR)
+                CASE(ERROR_VIDEO_STD_VERSION_NOT_SUPPORTED_KHR)
+        #endif
+                CASE(ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT)
+                CASE(ERROR_NOT_PERMITTED_KHR)
+                CASE(ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)
+                CASE(THREAD_IDLE_KHR)        CASE(THREAD_DONE_KHR)
+                CASE(OPERATION_DEFERRED_KHR) CASE(OPERATION_NOT_DEFERRED_KHR)
+                default: return "unknown";
+                }
+        #undef CASE
+    }
+    local proc vktry {call} { string map {\n " "} [csubst {{
+        VkResult res = $call;
         if (res != VK_SUCCESS) {
             FOLK_ERROR("Failed vkCreateInstance: %s (%d)\n",
                     VkResultToString(res), res);
@@ -184,118 +112,203 @@ $gpuc proc init {bool useGlfw} void {
                            "Did you install `vulkan-validationlayers`?\n");
             }
         }
+    }}] }
+
+    $gpuc define {
+        VkInstance instance;
+        VkPhysicalDevice physicalDevice;
+        VkPhysicalDeviceFeatures physicalDeviceFeatures;
+        VkPhysicalDeviceProperties physicalDeviceProperties;
+
+        VkDevice device;
+        uint32_t computeQueueFamilyIndex;
+        uint32_t graphicsQueueFamilyIndex = UINT32_MAX;
+
+        pthread_mutex_t graphicsQueueMutex;
+        VkQueue graphicsQueue;
+        VkQueue presentQueue;
+        VkQueue computeQueue;
+
+        pthread_mutex_t displaySurfaceMutex;
     }
-    volkLoadInstance(instance);
+    defineVulkanHandleType $gpuc VkPhysicalDevice
+    defineVulkanHandleType $gpuc VkDevice
+    $gpuc proc getPhysicalDevice {} VkPhysicalDevice { return physicalDevice; }
+    $gpuc proc getDevice {} VkDevice { return device; }
 
-    // Set up VkPhysicalDevice physicalDevice
-    {
-        uint32_t physicalDeviceCount = 0;
-        vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, NULL);
-        if (physicalDeviceCount == 0) {
-            FOLK_ERROR("Failed to find Vulkan physical device\n");
-        }
-        printf("gpu: Found %d Vulkan devices\n", physicalDeviceCount);
-        VkPhysicalDevice physicalDevices[physicalDeviceCount];
-        vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, physicalDevices);
+    $gpuc proc init {bool useGlfw} void {
+        $[vktry volkInitialize()]
+        $[if {$useGlfw} { expr {"glfwInit();"} }]
 
-        physicalDevice = physicalDevices[0];
-        vkGetPhysicalDeviceFeatures(physicalDevice, &physicalDeviceFeatures);
-        vkGetPhysicalDeviceProperties(physicalDevice, &physicalDeviceProperties);
-    }
+        // Set up VkInstance instance:
+        {
+            VkInstanceCreateInfo createInfo = {0};
+            createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
 
-    computeQueueFamilyIndex = UINT32_MAX; {
-        uint32_t queueFamilyCount = 0;
-        vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, NULL);
-        VkQueueFamilyProperties queueFamilies[queueFamilyCount];
-        vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, queueFamilies);
-        for (int i = 0; i < queueFamilyCount; i++) {
-            if (queueFamilies[i].queueFlags & VK_QUEUE_COMPUTE_BIT) {
-                computeQueueFamilyIndex = i;
+            const char* validationLayers[] = {
+               "VK_LAYER_KHRONOS_validation"
+            };
+            createInfo.enabledLayerCount = sizeof(validationLayers)/sizeof(validationLayers[0]);
+            createInfo.ppEnabledLayerNames = validationLayers;
+
+            $[if {$macos} {subst -nocommands {
+                const char* enabledExtensions[] = {
+                    VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME,
+                    VK_KHR_SURFACE_EXTENSION_NAME,
+                    "VK_EXT_metal_surface",
+                    VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
+                };
+                createInfo.enabledExtensionCount = sizeof(enabledExtensions)/sizeof(enabledExtensions[0]);
+
+            }} elseif {$useGlfw} {subst -nocommands {
+                const char** enabledExtensions = glfwGetRequiredInstanceExtensions(&createInfo.enabledExtensionCount);
+
+            }} else {subst -nocommands {
+                const char* enabledExtensions[] = {
+                    // 2 extensions for non-X11/Wayland display
+                    VK_KHR_SURFACE_EXTENSION_NAME,
+                    VK_KHR_DISPLAY_EXTENSION_NAME,
+                    VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
+                };
+                createInfo.enabledExtensionCount = sizeof(enabledExtensions)/sizeof(enabledExtensions[0]);
+            }}]
+            createInfo.ppEnabledExtensionNames = enabledExtensions;
+
+            $[if {$macos} { expr {{
+                createInfo.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+            }} }]
+            VkResult res = vkCreateInstance(&createInfo, NULL, &instance);
+            if (res != VK_SUCCESS) {
+                FOLK_ERROR("Failed vkCreateInstance: %s (%d)\n",
+                        VkResultToString(res), res);
+                if (res == VK_ERROR_LAYER_NOT_PRESENT) {
+                    FOLK_ERROR("It looks like a required layer is missing.\n"
+                               "Did you install `vulkan-validationlayers`?\n");
+                }
             }
-            if (queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
-                graphicsQueueFamilyIndex = i;
-                break;
+        }
+        volkLoadInstance(instance);
+
+        // Set up VkPhysicalDevice physicalDevice
+        {
+            uint32_t physicalDeviceCount = 0;
+            vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, NULL);
+            if (physicalDeviceCount == 0) {
+                FOLK_ERROR("Failed to find Vulkan physical device\n");
+            }
+            printf("gpu: Found %d Vulkan devices\n", physicalDeviceCount);
+            VkPhysicalDevice physicalDevices[physicalDeviceCount];
+            vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, physicalDevices);
+
+            physicalDevice = physicalDevices[0];
+            vkGetPhysicalDeviceFeatures(physicalDevice, &physicalDeviceFeatures);
+            vkGetPhysicalDeviceProperties(physicalDevice, &physicalDeviceProperties);
+        }
+
+        computeQueueFamilyIndex = UINT32_MAX; {
+            uint32_t queueFamilyCount = 0;
+            vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, NULL);
+            VkQueueFamilyProperties queueFamilies[queueFamilyCount];
+            vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, queueFamilies);
+            for (int i = 0; i < queueFamilyCount; i++) {
+                if (queueFamilies[i].queueFlags & VK_QUEUE_COMPUTE_BIT) {
+                    computeQueueFamilyIndex = i;
+                }
+                if (queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+                    graphicsQueueFamilyIndex = i;
+                    break;
+                }
+            }
+            if (graphicsQueueFamilyIndex == UINT32_MAX) {
+                fprintf(stderr, "Failed to find a Vulkan graphics queue family\n"); exit(1);
+            }
+            if (computeQueueFamilyIndex == UINT32_MAX) {
+                fprintf(stderr, "Failed to find a Vulkan compute queue family\n"); exit(1);
             }
         }
-        if (graphicsQueueFamilyIndex == UINT32_MAX) {
-            fprintf(stderr, "Failed to find a Vulkan graphics queue family\n"); exit(1);
+
+        // Set up VkDevice device
+        {
+            VkDeviceQueueCreateInfo queueCreateInfo = {0};
+            queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+            queueCreateInfo.queueFamilyIndex = graphicsQueueFamilyIndex;
+            queueCreateInfo.queueCount = 1;
+            float queuePriority = 1.0f;
+            queueCreateInfo.pQueuePriorities = &queuePriority;
+
+            VkPhysicalDeviceFeatures deviceFeatures = {0};
+
+            $[if {$macos} {subst -nocommands {
+                const char *deviceExtensions[] = {
+                    VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+                    "VK_KHR_portability_subset",
+                    VK_KHR_MAINTENANCE3_EXTENSION_NAME
+                };
+            }} elseif {$useGlfw} {subst -nocommands {
+                const char *deviceExtensions[] = {
+                    VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+                };
+            }} else {subst -nocommands {
+                const char *deviceExtensions[] = {
+                    VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+                    VK_KHR_MAINTENANCE3_EXTENSION_NAME
+                };
+            }}]
+
+            VkDeviceCreateInfo createInfo = {0};
+            createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+            createInfo.pQueueCreateInfos = &queueCreateInfo;
+            createInfo.queueCreateInfoCount = 1;
+            createInfo.pEnabledFeatures = &deviceFeatures;
+            createInfo.enabledLayerCount = 0;
+            createInfo.enabledExtensionCount = sizeof(deviceExtensions)/sizeof(deviceExtensions[0]);
+            createInfo.ppEnabledExtensionNames = deviceExtensions;
+
+            /* VkPhysicalDeviceDescriptorIndexingFeatures descriptorIndexingFeatures = {0}; */
+            /* descriptorIndexingFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES; */
+            /* descriptorIndexingFeatures.descriptorBindingPartiallyBound = VK_TRUE; */
+            /* // TODO: Do we need more descriptor indexing features? */
+            /* createInfo.pNext = &descriptorIndexingFeatures; */
+
+            $[vktry {vkCreateDevice(physicalDevice, &createInfo, NULL, &device)}]
         }
-        if (computeQueueFamilyIndex == UINT32_MAX) {
-            fprintf(stderr, "Failed to find a Vulkan compute queue family\n"); exit(1);
+
+        // Set up VkQueue graphicsQueue and VkQueue presentQueue and VkQueue computeQueue
+        {
+            pthread_mutex_init(&graphicsQueueMutex, NULL);
+            pthread_mutex_init(&displaySurfaceMutex, NULL);
+            vkGetDeviceQueue(device, graphicsQueueFamilyIndex, 0, &graphicsQueue);
+            presentQueue = graphicsQueue;
+            computeQueue = graphicsQueue;
         }
     }
-
-    // Set up VkDevice device
-    {
-        VkDeviceQueueCreateInfo queueCreateInfo = {0};
-        queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-        queueCreateInfo.queueFamilyIndex = graphicsQueueFamilyIndex;
-        queueCreateInfo.queueCount = 1;
-        float queuePriority = 1.0f;
-        queueCreateInfo.pQueuePriorities = &queuePriority;
-
-        VkPhysicalDeviceFeatures deviceFeatures = {0};
-
-        $[if {$macos} {subst -nocommands {
-            const char *deviceExtensions[] = {
-                VK_KHR_SWAPCHAIN_EXTENSION_NAME,
-                "VK_KHR_portability_subset",
-                VK_KHR_MAINTENANCE3_EXTENSION_NAME
-            };
-        }} elseif {$useGlfw} {subst -nocommands {
-            const char *deviceExtensions[] = {
-                VK_KHR_SWAPCHAIN_EXTENSION_NAME,
-            };
-        }} else {subst -nocommands {
-            const char *deviceExtensions[] = {
-                VK_KHR_SWAPCHAIN_EXTENSION_NAME,
-                VK_KHR_MAINTENANCE3_EXTENSION_NAME
-            };
-        }}]
-
-        VkDeviceCreateInfo createInfo = {0};
-        createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-        createInfo.pQueueCreateInfos = &queueCreateInfo;
-        createInfo.queueCreateInfoCount = 1;
-        createInfo.pEnabledFeatures = &deviceFeatures;
-        createInfo.enabledLayerCount = 0;
-        createInfo.enabledExtensionCount = sizeof(deviceExtensions)/sizeof(deviceExtensions[0]);
-        createInfo.ppEnabledExtensionNames = deviceExtensions;
-
-        /* VkPhysicalDeviceDescriptorIndexingFeatures descriptorIndexingFeatures = {0}; */
-        /* descriptorIndexingFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES; */
-        /* descriptorIndexingFeatures.descriptorBindingPartiallyBound = VK_TRUE; */
-        /* // TODO: Do we need more descriptor indexing features? */
-        /* createInfo.pNext = &descriptorIndexingFeatures; */
-
-        $[vktry {vkCreateDevice(physicalDevice, &createInfo, NULL, &device)}]
+    $gpuc proc getDoesSupportShaderSampledImageArrayDynamicIndexing {} bool {
+        return physicalDeviceFeatures.shaderSampledImageArrayDynamicIndexing;
+    }
+    $gpuc proc getMaxTextures {} int {
+        int maxTextures = physicalDeviceProperties.limits.maxPerStageDescriptorSamplers;
+        // If it's actually a low cap (often 16), stick with that.
+        if (maxTextures < 128) { return maxTextures; }
+        // HACK: for now, I don't want to deal with all the other descriptor caps etc.
+        return 128;
     }
 
-    // Set up VkQueue graphicsQueue and VkQueue presentQueue and VkQueue computeQueue
-    {
-        pthread_mutex_init(&graphicsQueueMutex, NULL);
-        vkGetDeviceQueue(device, graphicsQueueFamilyIndex, 0, &graphicsQueue);
-        presentQueue = graphicsQueue;
-        computeQueue = graphicsQueue;
+    set gpuLib [$gpuc compile]
+
+    $gpuLib init $useGlfw
+    Claim the GPU library is $gpuLib
+
+    Claim the GPU physical device is [$gpuLib getPhysicalDevice]
+    Claim the GPU device is [$gpuLib getDevice]
+}
+
+When $::thisNode has had displays enumerated {
+    # so we know that there isn't an extant Vulkan instance already.
+
+    When /nobody/ wishes $::thisNode uses display "glfw" with /...any/ {
+        gpuInit false
     }
-}
-$gpuc proc getDoesSupportShaderSampledImageArrayDynamicIndexing {} bool {
-    return physicalDeviceFeatures.shaderSampledImageArrayDynamicIndexing;
-}
-$gpuc proc getMaxTextures {} int {
-    int maxTextures = physicalDeviceProperties.limits.maxPerStageDescriptorSamplers;
-    // If it's actually a low cap (often 16), stick with that.
-    if (maxTextures < 128) { return maxTextures; }
-    // HACK: for now, I don't want to deal with all the other descriptor caps etc.
-    return 128;
-}
-
-set gpuLib [$gpuc compile]
-
-$gpuLib init $useGlfw
-Claim the GPU library is $gpuLib
-
-Claim the GPU physical device is [$gpuLib getPhysicalDevice]
-Claim the GPU device is [$gpuLib getDevice]
-
+    When /someone/ wishes $::thisNode uses display "glfw" with /...any/ {
+        gpuInit true
+    }
 }

--- a/builtin-programs/gpu/gpu.folk
+++ b/builtin-programs/gpu/gpu.folk
@@ -282,6 +282,40 @@ fn gpuInit {useGlfw} {
             computeQueue = graphicsQueue;
         }
     }
+    # Thread-local command pool and command buffer helpers. These are
+    # used by textures, canvases, and draw code across all displays.
+    $gpuc code {
+        __thread VkCommandPool _commandPool;
+        __thread VkCommandBuffer _commandBuffer;
+    }
+    defineVulkanHandleType $gpuc VkCommandPool
+    defineVulkanHandleType $gpuc VkCommandBuffer
+    $gpuc proc getCommandPool {} VkCommandPool {
+        if (_commandPool == 0) {
+            VkCommandPoolCreateInfo poolInfo = {0};
+            poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+            poolInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+            poolInfo.queueFamilyIndex = graphicsQueueFamilyIndex;
+
+            VkResult res = vkCreateCommandPool(device, &poolInfo, NULL, &_commandPool);
+            if (res != VK_SUCCESS) { fprintf(stderr, "Failed to create command pool: %d\\n", res); exit(1); }
+        }
+        return _commandPool;
+    }
+    $gpuc proc getCommandBuffer {} VkCommandBuffer {
+        if (_commandBuffer == 0) {
+            VkCommandBufferAllocateInfo allocInfo = {0};
+            allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+            allocInfo.commandPool = getCommandPool();
+            allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+            allocInfo.commandBufferCount = 1;
+
+            VkResult res = vkAllocateCommandBuffers(device, &allocInfo, &_commandBuffer);
+            if (res != VK_SUCCESS) { fprintf(stderr, "Failed to allocate command buffer: %d\\n", res); exit(1); }
+        }
+        return _commandBuffer;
+    }
+
     $gpuc proc getDoesSupportShaderSampledImageArrayDynamicIndexing {} bool {
         return physicalDeviceFeatures.shaderSampledImageArrayDynamicIndexing;
     }

--- a/builtin-programs/gpu/pipelines.folk
+++ b/builtin-programs/gpu/pipelines.folk
@@ -1,0 +1,298 @@
+# pipelines.folk --
+#
+#     Shared render pass, pipeline creation, and shader compilation.
+#     Created once (not per-display). Pipelines use dynamic viewport/scissor
+#     so they work across displays of different sizes.
+
+When the GPU Vulkan handle type definer is /defineVulkanHandleType/ &\
+     the GPU library is /gpuLib/ &\
+     the image library is /imageLib/ &\
+     the GPU texture library is /gpuTextureLib/ {
+
+fn defineVulkanHandleType
+
+set cc [C]
+$cc cflags -I./vendor
+$cc include <pthread.h>
+$cc code {
+    #define VOLK_IMPLEMENTATION
+    #include "volk/volk.h"
+}
+
+$cc extend $gpuLib
+$cc extend $imageLib
+$cc extend -noprocs $gpuTextureLib
+
+local proc vktry {call} { string map {\n " "} [csubst {{
+    VkResult res = $call;
+    if (res != VK_SUCCESS) {
+        fprintf(stderr, "Failed $call: %s (%d)\n",
+                VkResultToString(res), res); exit(1);
+    }
+}}] }
+
+$cc code {
+    VkDevice device;
+}
+
+$cc define {
+    VkRenderPass renderPass;
+}
+
+# Shader compilation:
+defineVulkanHandleType $cc VkShaderModule
+$cc proc createShaderModule {Jim_Obj* codeObj} VkShaderModule {
+    int codeObjc = Jim_ListLength(interp, codeObj);
+    uint32_t* code = malloc(codeObjc * sizeof(uint32_t));
+    for (int i = 0; i < codeObjc; i++) {
+        Jim_Obj* codeObjv = Jim_ListGetIndex(interp, codeObj, i);
+        long val;
+        Jim_GetLong(interp, codeObjv, &val);
+        code[i] = (uint32_t)val;
+    }
+
+    VkShaderModuleCreateInfo createInfo = {0};
+    createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    createInfo.codeSize = codeObjc * sizeof(uint32_t);
+    createInfo.pCode = code;
+
+    VkShaderModule shaderModule;
+    $[vktry {vkCreateShaderModule(device, &createInfo, NULL, &shaderModule)}]
+    free(code);
+    return shaderModule;
+}
+
+# Pipeline creation:
+defineVulkanHandleType $cc VkPipeline
+defineVulkanHandleType $cc VkPipelineLayout
+defineVulkanHandleType $cc VkDescriptorSet
+$cc typedef uint64_t VkDeviceSize
+$cc argtype VkDescriptorType { int $argname; __ENSURE_OK(Tcl_GetIntFromObj(interp, $obj, &$argname)); }
+$cc rtype VkDescriptorType { $robj = Tcl_NewIntObj($rvalue); }
+
+$cc code {
+    typedef struct PushConstantsEncoder {
+        int (*encode)(Jim_Interp* interp, Jim_Obj* obj, uint8_t out[128]);
+    } PushConstantsEncoder;
+} :extend ;# needs to be available for an extender in order for
+           # Pipeline to be defined.
+$cc struct Pipeline {
+    VkPipeline pipeline;
+    VkPipelineLayout pipelineLayout;
+
+    size_t pushConstantsSize;
+    PushConstantsEncoder* encodePushConstants;
+}
+
+$cc proc createPipeline {VkShaderModule vertShaderModule
+                           VkShaderModule fragShaderModule
+                           PushConstantsEncoder* encodePushConstants
+                           size_t pushConstantsSize} Pipeline {
+        VkPipelineShaderStageCreateInfo shaderStages[2]; {
+        VkPipelineShaderStageCreateInfo vertShaderStageInfo = {0};
+        vertShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        vertShaderStageInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
+        vertShaderStageInfo.module = vertShaderModule;
+        vertShaderStageInfo.pName = "main";
+
+        VkPipelineShaderStageCreateInfo fragShaderStageInfo = {0};
+        fragShaderStageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        fragShaderStageInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+        fragShaderStageInfo.module = fragShaderModule;
+        fragShaderStageInfo.pName = "main";
+
+        shaderStages[0] = vertShaderStageInfo;
+        shaderStages[1] = fragShaderStageInfo;
+    }
+
+    VkPipelineVertexInputStateCreateInfo vertexInputInfo = {0}; {
+        vertexInputInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+        vertexInputInfo.vertexBindingDescriptionCount = 0;
+        vertexInputInfo.vertexAttributeDescriptionCount = 0;
+    }
+
+    VkPipelineInputAssemblyStateCreateInfo inputAssembly = {0}; {
+        inputAssembly.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+        inputAssembly.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+        inputAssembly.primitiveRestartEnable = VK_FALSE;
+    }
+
+    // Dummy viewport/scissor — overridden by dynamic state at draw time.
+    VkViewport viewport = {0}; {
+        viewport.width = 1.0f;
+        viewport.height = 1.0f;
+        viewport.maxDepth = 1.0f;
+    }
+    VkRect2D scissor = {0}; {
+        scissor.extent = (VkExtent2D) {1, 1};
+    }
+    VkPipelineViewportStateCreateInfo viewportState = {0};
+    viewportState.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    viewportState.viewportCount = 1;
+    viewportState.pViewports = &viewport;
+    viewportState.scissorCount = 1;
+    viewportState.pScissors = &scissor;
+
+    VkPipelineRasterizationStateCreateInfo rasterizer = {0};
+    rasterizer.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    rasterizer.depthClampEnable = VK_FALSE;
+    rasterizer.rasterizerDiscardEnable = VK_FALSE;
+    rasterizer.polygonMode = VK_POLYGON_MODE_FILL;
+    rasterizer.lineWidth = 1.0f;
+    rasterizer.cullMode = VK_CULL_MODE_BACK_BIT;
+    rasterizer.frontFace = VK_FRONT_FACE_CLOCKWISE;
+    rasterizer.depthBiasEnable = VK_FALSE;
+
+    VkPipelineMultisampleStateCreateInfo multisampling = {0};
+    multisampling.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    multisampling.sampleShadingEnable = VK_FALSE;
+    multisampling.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineColorBlendAttachmentState colorBlendAttachment = {0};
+    colorBlendAttachment.colorWriteMask =
+      VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT |
+      VK_COLOR_COMPONENT_A_BIT;
+    colorBlendAttachment.blendEnable = VK_TRUE;
+    colorBlendAttachment.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+    colorBlendAttachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    colorBlendAttachment.colorBlendOp = VK_BLEND_OP_ADD;
+    colorBlendAttachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+    colorBlendAttachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+    colorBlendAttachment.alphaBlendOp = VK_BLEND_OP_ADD;
+
+    VkPipelineColorBlendStateCreateInfo colorBlending = {0};
+    colorBlending.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    colorBlending.logicOpEnable = VK_FALSE;
+    colorBlending.logicOp = VK_LOGIC_OP_COPY;
+    colorBlending.attachmentCount = 1;
+    colorBlending.pAttachments = &colorBlendAttachment;
+
+    VkPipelineDynamicStateCreateInfo dynamicState = {0};
+    dynamicState.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dynamicState.dynamicStateCount = 2;
+    VkDynamicState dynamicStates[] = {
+        VK_DYNAMIC_STATE_VIEWPORT,
+        VK_DYNAMIC_STATE_SCISSOR
+    };
+    dynamicState.pDynamicStates = dynamicStates;
+
+    VkPipelineLayout pipelineLayout; {
+        VkPipelineLayoutCreateInfo pipelineLayoutInfo = {0};
+        pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+
+        pipelineLayoutInfo.pSetLayouts = textureDescriptorSetLayout_ptr();
+        pipelineLayoutInfo.setLayoutCount = 1;
+
+        // We configure all pipelines with push constants size =
+        // 128 (the maximum), no matter what actual push constants
+        // they take; this is so that pipelines are all
+        // layout-compatible so we can reuse descriptor set
+        // between pipelines without needing to rebind it.
+        VkPushConstantRange pushConstantRange = {0};
+        pushConstantRange.offset = 0;
+        pushConstantRange.size = 128;
+        pushConstantRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+
+        pipelineLayoutInfo.pPushConstantRanges = &pushConstantRange;
+        pipelineLayoutInfo.pushConstantRangeCount = 1;
+
+        $[vktry {vkCreatePipelineLayout(device, &pipelineLayoutInfo, NULL, &pipelineLayout)}]
+    }
+
+    VkPipeline pipeline; {
+        VkGraphicsPipelineCreateInfo pipelineInfo = {0};
+        pipelineInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+        pipelineInfo.stageCount = 2;
+        pipelineInfo.pStages = shaderStages;
+        pipelineInfo.pVertexInputState = &vertexInputInfo;
+        pipelineInfo.pInputAssemblyState = &inputAssembly;
+        pipelineInfo.pViewportState = &viewportState;
+        pipelineInfo.pRasterizationState = &rasterizer;
+        pipelineInfo.pMultisampleState = &multisampling;
+        pipelineInfo.pDepthStencilState = NULL;
+        pipelineInfo.pColorBlendState = &colorBlending;
+        pipelineInfo.pDynamicState = &dynamicState;
+
+        pipelineInfo.layout = pipelineLayout;
+
+        pipelineInfo.renderPass = renderPass;
+        pipelineInfo.subpass = 0;
+
+        pipelineInfo.basePipelineHandle = VK_NULL_HANDLE;
+        pipelineInfo.basePipelineIndex = -1;
+
+        $[vktry {vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, NULL, &pipeline)}]
+    }
+
+    return (Pipeline) {
+        .pipeline = pipeline,
+        .pipelineLayout = pipelineLayout,
+        .pushConstantsSize = pushConstantsSize,
+        .encodePushConstants = encodePushConstants
+    };
+}
+
+# Bind the shared texture descriptor set on a command buffer.
+$cc proc bindTextureDescriptorSet {VkCommandBuffer commandBuffer VkPipelineLayout pipelineLayout} void {
+    vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                            pipelineLayout, 0, 1, textureDescriptorSet_ptr(), 0, NULL);
+}
+$cc proc getTextureDescriptorSet {} VkDescriptorSet {
+    return *textureDescriptorSet_ptr();
+}
+
+$cc proc pipelinesInit {} void {
+    $[vktry volkInitialize()]
+    volkLoadInstanceOnly(*instance_ptr());
+
+    device = *device_ptr();
+    volkLoadDevice(device);
+
+    // Set up VkRenderPass renderPass:
+    {
+        VkAttachmentDescription colorAttachment = {0};
+        colorAttachment.format = VK_FORMAT_B8G8R8A8_UNORM;
+        colorAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
+        colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        colorAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        colorAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        colorAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        colorAttachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+
+        VkAttachmentReference colorAttachmentRef = {0};
+        colorAttachmentRef.attachment = 0;
+        colorAttachmentRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass = {0};
+        subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass.colorAttachmentCount = 1;
+        subpass.pColorAttachments = &colorAttachmentRef;
+
+        VkRenderPassCreateInfo renderPassInfo = {0};
+        renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+        renderPassInfo.attachmentCount = 1;
+        renderPassInfo.pAttachments = &colorAttachment;
+        renderPassInfo.subpassCount = 1;
+        renderPassInfo.pSubpasses = &subpass;
+
+        VkSubpassDependency dependency = {0};
+        dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+        dependency.dstSubpass = 0;
+        dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        dependency.srcAccessMask = 0;
+        dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+
+        renderPassInfo.dependencyCount = 1;
+        renderPassInfo.pDependencies = &dependency;
+
+        $[vktry {vkCreateRenderPass(device, &renderPassInfo, NULL, &renderPass)}]
+    }
+}
+
+set pipelineLib [$cc compile]
+$pipelineLib pipelinesInit
+Claim the GPU pipeline library is $pipelineLib
+
+}

--- a/builtin-programs/gpu/textures.folk
+++ b/builtin-programs/gpu/textures.folk
@@ -1,6 +1,5 @@
 When the GPU Vulkan handle type definer is /defineVulkanHandleType/ &\
      the GPU library is /gpuLib/ &\
-     the GPU draw library is /drawLib/ &\
      the GPU VMA DLL is /vmaDll/ &\
      the image library is /imageLib/ {
 
@@ -24,11 +23,8 @@ $gpuc code {
 }
 $gpuc include <pthread.h>
 $gpuc include <stdatomic.h>
-$gpuc typedef {struct PushConstantsEncoder} PushConstantsEncoder
-$gpuc typedef {struct Pipeline} Pipeline
 
 $gpuc extend $gpuLib
-$gpuc extend $drawLib
 $gpuc extend $imageLib
 
 $gpuc include <pthread.h>
@@ -72,6 +68,13 @@ local proc vktry {call} { string map {\n " "} [csubst {{
 # - https://chunkstories.xyz/blog/a-note-on-descriptor-indexing/
 # - https://gist.github.com/DethRaid/0171f3cfcce51950ee4ef96c64f59617
 # - http://roar11.com/2019/06/vulkan-textures-unbound/
+$gpuc define {
+    VkDescriptorSetLayout textureDescriptorSetLayout;
+    VkDescriptorSet textureDescriptorSet;
+}
+defineVulkanHandleType $gpuc VkDescriptorSetLayout
+defineVulkanHandleType $gpuc VkDescriptorSet
+
 $gpuc code {
     VkDevice device;
     static void initPlaceholderTexture();
@@ -780,9 +783,11 @@ $gpuc proc initPlaceholderTexture {} void {
 }
 
 set gpuTextureLib [$gpuc compile]
-Claim the GPU texture library for $drawLib is $gpuTextureLib
 
-# Wait until the library has been initialized by gpu.folk.
+$gpuTextureLib textureManagerInit
+
+Claim the GPU texture library is $gpuTextureLib
+
 When display /any/ has width /any/ height /any/ {
     Wish the GPU runs frame prelude handler [list apply {{gpuTextureLib} {
         $gpuTextureLib processDeferredTextureOps

--- a/builtin-programs/gpu/textures.folk
+++ b/builtin-programs/gpu/textures.folk
@@ -788,16 +788,14 @@ $gpuTextureLib textureManagerInit
 
 Claim the GPU texture library is $gpuTextureLib
 
-When display /any/ has width /any/ height /any/ {
-    Wish the GPU runs frame prelude handler [list apply {{gpuTextureLib} {
-        $gpuTextureLib processDeferredTextureOps
-    }} $gpuTextureLib]
+Wish the GPU runs frame prelude handler [list apply {{gpuTextureLib} {
+    $gpuTextureLib processDeferredTextureOps
+}} $gpuTextureLib]
 
-    When /someone/ wishes the GPU loads image /im/ as texture {
-        set gtex [$gpuTextureLib copyImageToGpuTexture $im]
-        Claim the GPU has loaded image $im as texture $gtex \
-            -destructor [list $gpuTextureLib freeGpuTexture $gtex]
-    }
+When /someone/ wishes the GPU loads image /im/ as texture {
+    set gtex [$gpuTextureLib copyImageToGpuTexture $im]
+    Claim the GPU has loaded image $im as texture $gtex \
+        -destructor [list $gpuTextureLib freeGpuTexture $gtex]
 }
 
 }

--- a/builtin-programs/gpu/textures.folk
+++ b/builtin-programs/gpu/textures.folk
@@ -568,21 +568,77 @@ $gpuc proc createGpuTexture {int width int height int format} GpuTextureBlock* {
     return block;
 }
 
+# In-flight texture upload ring, per worker thread. Lets
+# copyImageToGpuTexture submit a staging-buffer->image copy without
+# waiting for it to complete; the staging buffer is reclaimed lazily
+# on a later call once the GPU is done with it. We only block when
+# the ring fills up (i.e. we've pipelined enough uploads that the
+# oldest one still isn't done), which is the natural backpressure
+# point for a single worker.
+$gpuc code {
+    #define INFLIGHT_UPLOADS 8
+    struct InflightUpload {
+        VkCommandBuffer cmdBuffer;
+        VkFence fence;
+        VkBuffer stagingBuffer;
+        VmaAllocation stagingBufferAllocation;
+        bool inUse;
+    };
+    static __thread struct InflightUpload _inflightUploads[INFLIGHT_UPLOADS];
+    static __thread int _inflightUploadsNext = 0;
+
+    // Reclaim a slot: if it holds an outstanding upload, wait for its
+    // fence, destroy its staging buffer, reset fence. Returns the slot
+    // with fence + cmdBuffer allocated and ready to use.
+    static struct InflightUpload* acquireInflightUpload() {
+        struct InflightUpload* slot = &_inflightUploads[_inflightUploadsNext];
+        _inflightUploadsNext = (_inflightUploadsNext + 1) % INFLIGHT_UPLOADS;
+
+        if (slot->inUse) {
+#ifdef TRACY_ENABLE
+            TracyCZoneN(ctx, "vkWaitForFences (ring full)", 1);
+#endif
+            vkWaitForFences(device, 1, &slot->fence, VK_TRUE, UINT64_MAX);
+#ifdef TRACY_ENABLE
+            TracyCZoneEnd(ctx);
+            TracyCFree(slot->stagingBufferAllocation);
+#endif
+            vmaDestroyBuffer(vmaGetAllocator(),
+                             slot->stagingBuffer, slot->stagingBufferAllocation);
+            slot->inUse = false;
+        }
+        if (slot->fence == VK_NULL_HANDLE) {
+            VkFenceCreateInfo fenceInfo = {0};
+            fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+            vkCreateFence(device, &fenceInfo, NULL, &slot->fence);
+        } else {
+            vkResetFences(device, 1, &slot->fence);
+        }
+        if (slot->cmdBuffer == VK_NULL_HANDLE) {
+            VkCommandBufferAllocateInfo allocInfo = {0};
+            allocInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+            allocInfo.commandPool = getCommandPool();
+            allocInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+            allocInfo.commandBufferCount = 1;
+            vkAllocateCommandBuffers(device, &allocInfo, &slot->cmdBuffer);
+        }
+        return slot;
+    }
+}
+
 $gpuc proc copyImageToGpuTexture {Image im} GpuTextureHandle {
-    VkFence fence = getFence(); // handles deferred staging buffer cleanup if needed
+    struct InflightUpload* upload = acquireInflightUpload();
 
     size_t size = im.width * im.height * 4;
     FOLK_ENSURE(size > 0);
 
-    VkBuffer stagingBuffer;
-    VmaAllocation stagingBufferAllocation;
     createBuffer(size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                  VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-                 &stagingBuffer, &stagingBufferAllocation);
+                 &upload->stagingBuffer, &upload->stagingBufferAllocation);
 
     // Copy im to stagingBuffer:
     {
-        void* data; vmaMapMemory(vmaGetAllocator(), stagingBufferAllocation, &data);
+        void* data; vmaMapMemory(vmaGetAllocator(), upload->stagingBufferAllocation, &data);
         Image stagingIm = (Image) {
             .width = im.width, .height = im.height,
             .components = 4,
@@ -590,15 +646,22 @@ $gpuc proc copyImageToGpuTexture {Image im} GpuTextureHandle {
             .data = data
         };
         copyImageToRgba(im, stagingIm);
-        vmaUnmapMemory(vmaGetAllocator(), stagingBufferAllocation);
+        vmaUnmapMemory(vmaGetAllocator(), upload->stagingBufferAllocation);
     }
 
     // Allocate a texture and texture block:
     GpuTextureBlock* block = createGpuTexture(im.width, im.height, VK_FORMAT_R8G8B8A8_SRGB);
 
-    // Copy stagingBuffer to block->textureImage with single command buffer:
+    // Record + submit staging buffer -> image copy. We do NOT wait on
+    // the fence here; a later call to acquireInflightUpload will
+    // reclaim this slot's staging buffer once the GPU is done.
     {
-        VkCommandBuffer commandBuffer = beginSingleTimeCommands();
+        VkCommandBuffer commandBuffer = upload->cmdBuffer;
+
+        VkCommandBufferBeginInfo beginInfo = {0};
+        beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        vkBeginCommandBuffer(commandBuffer, &beginInfo);
 
         // Transition to transfer destination
         VkImageMemoryBarrier barrier = {0};
@@ -634,7 +697,7 @@ $gpuc proc copyImageToGpuTexture {Image im} GpuTextureHandle {
         region.imageOffset = (VkOffset3D) {0, 0, 0};
         region.imageExtent = (VkExtent3D) {im.width, im.height, 1};
         vkCmdCopyBufferToImage(commandBuffer,
-                               stagingBuffer,
+                               upload->stagingBuffer,
                                block->textureImage,
                                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                                1,
@@ -650,23 +713,20 @@ $gpuc proc copyImageToGpuTexture {Image im} GpuTextureHandle {
                              VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
                              0, 0, NULL, 0, NULL, 1, &barrier);
 
-        endSingleTimeCommands(commandBuffer, fence);
+        vkEndCommandBuffer(commandBuffer);
 
-#ifdef TRACY_ENABLE
-        TracyCZoneN(ctx, "vkWaitForFences", 1);
-#endif
-        vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
-#ifdef TRACY_ENABLE
-        TracyCZoneEnd(ctx);
-#endif
+        VkSubmitInfo submitInfo = {0};
+        submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        submitInfo.commandBufferCount = 1;
+        submitInfo.pCommandBuffers = &commandBuffer;
+
+        pthread_mutex_lock(graphicsQueueMutex_ptr());
+        vkQueueSubmit(*graphicsQueue_ptr(), 1, &submitInfo, upload->fence);
+        pthread_mutex_unlock(graphicsQueueMutex_ptr());
     }
 
+    upload->inUse = true;
     addToTextureDescriptorSet(block->handle);
-
-#ifdef TRACY_ENABLE
-    TracyCFree(stagingBufferAllocation);
-#endif
-    vmaDestroyBuffer(vmaGetAllocator(), stagingBuffer, stagingBufferAllocation);
 
     return block->handle;
 }

--- a/builtin-programs/gpu/vma.folk
+++ b/builtin-programs/gpu/vma.folk
@@ -28,6 +28,8 @@ void vmaInit(VkInstance instance, VkPhysicalDevice physicalDevice, VkDevice devi
              PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr,
              PFN_vkGetPhysicalDeviceProperties vkGetPhysicalDeviceProperties,
              PFN_vkGetPhysicalDeviceMemoryProperties vkGetPhysicalDeviceMemoryProperties) {
+    if (allocator != VK_NULL_HANDLE) { return; }
+
     volkInitialize();
     volkLoadInstanceOnly(instance);
     volkLoadDevice(device);

--- a/builtin-programs/laser.folk
+++ b/builtin-programs/laser.folk
@@ -1,8 +1,10 @@
-When the image library is /imageLib/ {
+When the image library is /imageLib/ &\
+     libapriltag has been built with config /configCcWithLibapriltag/ {
+fn configCcWithLibapriltag
 
 set cc [C]
-$cc cflags -I./vendor/apriltag
-$cc endcflags vendor/blobdetect/hk.c ./vendor/apriltag/build/libapriltag.so
+configCcWithLibapriltag $cc
+$cc endcflags vendor/blobdetect/hk.c
 $cc extend $imageLib
 
 $cc include <apriltag.h>

--- a/builtin-programs/print.folk
+++ b/builtin-programs/print.folk
@@ -17,14 +17,15 @@
 #     Claim printer my-printer is the default printer
 #     Claim paper format a4 is the default paper format
 
-When libapriltag has been built &\
+When libapriltag has been built with config /configCcWithLibapriltag/ &\
      the image library is /imageLib/ &\
      the program save directory is /saveDir/ {
+fn configCcWithLibapriltag
 
 set cc [C]
 $cc extend $imageLib
-$cc cflags -I./vendor/apriltag -Wall -Werror
-$cc endcflags ./vendor/apriltag/build/libapriltag.so
+$cc cflags -Wall -Werror
+configCcWithLibapriltag $cc
 
 $cc code {
     #include <apriltag.h>

--- a/builtin-programs/tags-to-quads.folk
+++ b/builtin-programs/tags-to-quads.folk
@@ -1,4 +1,5 @@
-When libapriltag has been built {
+When libapriltag has been built with config /configCcWithLibapriltag/ {
+fn configCcWithLibapriltag
 
 set cc [C]
 
@@ -80,8 +81,7 @@ $cc proc rescaleAndUndistort {Intrinsics intr
     out[0] = x*intr.fx + intr.cx;
     out[1] = y*intr.fy + intr.cy;
 }
-$cc cflags -I./vendor/apriltag
-$cc endcflags ./vendor/apriltag/build/libapriltag.so
+configCcWithLibapriltag $cc
 
 $cc include <apriltag_pose.h>
 $cc include <math.h>

--- a/builtin-programs/title.folk
+++ b/builtin-programs/title.folk
@@ -1,6 +1,9 @@
 # Title/footnote wish fulfillment
 # for wishes of the form:
-# "Wish $tag is titled "This is a tag"" or "Wish $tag is footnoted "This is a footnote""
+# Wish $this is titled "This is a tag"
+# Wish $this is footnoted "This is a footnote"
+# Wish $this is right-margined "This is right-margined text"
+# Wish $this is left-margined "This is left-margined text"
 
 When /thing/ has quad /quad/ {
     Claim -keep 50ms $thing has a quad
@@ -15,64 +18,63 @@ When the quad library is /quadLib/ &\
 
     fn quadChange
 
-    When the collected results for [list /someone/ wishes $thing is titled /text/] are /results/ {
-        set text [join [lmap result $results {dict get $result text}] "\n"]
-        if {$text eq ""} { return }
-    
-        When -atomically $thing has quad /q/ {
-            # HACK: This is just direct working with pixels, like
-            # points-at, and it's ugly.
+    foreach {label edge textAnchor} {
+        titled         top    bottom
+        footnoted      bottom top
+        right-margined right  left
+        left-margined  left   right
+    } {
+        When the collected results for [list /someone/ wishes $thing is $label /text/] are /results/ {
+            set text [join [lmap result $results {dict get $result text}] "\n"]
+            if {$text eq ""} { return }
 
-            lassign [$quadLib vertices [quadChange $q "display $disp"]] \
-                topLeft topRight
+            When -atomically $thing has quad /q/ {
+                package require linalg
+                namespace import \
+                    ::math::linearalgebra::add \
+                    ::math::linearalgebra::sub \
+                    ::math::linearalgebra::scale \
+                    ::math::linearalgebra::unitLengthVector
 
-            set dispTopLeft [$poseLib project $displayIntrinsics \
-                                 $displayWidth $displayHeight $topLeft]
-            set dispTopRight [$poseLib project $displayIntrinsics \
-                                 $displayWidth $displayHeight $topRight]
-            set dispTopCenter [vec2 midpoint $dispTopLeft $dispTopRight]
-            set dispTop [vec2 sub $dispTopRight $dispTopLeft]
-            set dispRadians [expr {-atan2([lindex $dispTop 1], [lindex $dispTop 0])}]
-            Wish to draw text onto $disp with \
-                position $dispTopCenter \
-                scale 36.0 radians $dispRadians anchor bottom \
-                text $text
-        }
-    }
+                lassign [$quadLib vertices [quadChange $q "display $disp"]] \
+                    topLeft topRight bottomRight bottomLeft
 
-    When the collected results for [list /someone/ wishes $thing is footnoted /text/] are /results/ {
-        set text [join [lmap result $results {dict get $result text}] "\n"]
-        if {$text eq ""} { return }
+                switch $edge {
+                    top { 
+                        set physicalPos [scale 0.5 [add $topLeft $topRight]]
+                        set physicalDir [sub $topLeft $bottomLeft]
+                    }
+                    bottom { 
+                        set physicalPos [scale 0.5 [add $bottomLeft $bottomRight]]
+                        set physicalDir [sub $bottomLeft $topLeft]
+                    }
+                    right { 
+                        set physicalPos [scale 0.5 [add $topRight $bottomRight]]
+                        set physicalDir [sub $topRight $topLeft]
+                    }
+                    left { 
+                        set physicalPos [scale 0.5 [add $topLeft $bottomLeft]]
+                        set physicalDir [sub $topLeft $topRight]
+                    }
+                }
 
-        set radians [region angle $region]
-        When $thing has region /region/ {
-            set scale [dict getdef $result scale 0.75]
-            set pos [region bottomleft [region move $region down 20px]]
-            Wish to draw text with position $pos scale $scale text $text radians $radians anchor topleft
-        }
-    }
-    
-    When the collected results for [list /someone/ wishes $thing is right-margined /text/] are /results/ {
-        set text [join [lmap result $results {dict get $result text}] "\n"]
-        if {$text eq ""} { return }
+                set paddingMeters 0.02
+                set offset [scale $paddingMeters [unitLengthVector $physicalDir]]
+                set physicalPos [add $physicalPos $offset]
 
-        set radians [region angle $region]
-        When $thing has region /region/ {
-            set scale [dict getdef $result scale 0.75]
-            set pos [region right [region move $region right 10px]]
-            Wish to draw text with position $pos scale $scale text $text radians $radians anchor left
-        }
-    }
+                set dispPosition [$poseLib project $displayIntrinsics $displayWidth $displayHeight $physicalPos]
 
-    When the collected results for [list /someone/ wishes $thing is left-margined /text/] are /results/ {
-        set text [join [lmap result $results {dict get $result text}] "\n"]
-        if {$text eq ""} { return }
+                set dispTopLeft [$poseLib project $displayIntrinsics $displayWidth $displayHeight $topLeft]
+                set dispTopRight [$poseLib project $displayIntrinsics $displayWidth $displayHeight $topRight]
+                
+                set dispTop [vec2 sub $dispTopRight $dispTopLeft]
+                set dispRadians [expr {-atan2([lindex $dispTop 1], [lindex $dispTop 0])}]
 
-        set radians [region angle $region]
-        When $thing has region /region/ {
-            set scale [dict getdef $result scale 0.75]
-            set pos [region left [region move $region left 10px]]
-            Wish to draw text with position $pos scale $scale text $text radians $radians anchor right
+                Wish to draw text onto $disp with \
+                    position $dispPosition \
+                    scale 36.0 radians $dispRadians anchor $textAnchor \
+                    text $text
+            }
         }
     }
 }

--- a/builtin-programs/web/camera.folk
+++ b/builtin-programs/web/camera.folk
@@ -1,6 +1,27 @@
 Wish the web server handles route {/camera} with handler {
-    set camera [dict getdef $QUERY camera /any/]
-    html {
+    if {[dict exists $QUERY camera]} {
+        set camera [dict get $QUERY camera]
+    } else {
+        set cameraResults [Query! /someone/ wishes $::thisNode uses camera /camera/ with /...any/]
+        if {[llength $cameraResults] == 1} {
+            set camera [dict get [lindex $cameraResults 0] camera]
+        } else {
+            return [html [subst {
+                <html>
+                <body>
+                <p>Choose a camera:</p>
+                <ul>
+                [join [lmap result $cameraResults { subst {
+                    <li><a href="/camera?camera=[string map {/ %2F} $result(camera)]">$result(camera)</a></li>
+                } }] \n]
+                </ul>
+                </body>
+                </html>
+            }]]
+        }
+    }
+
+    html [subst {
 <html>
   <body style="margin: 0 0">
     <canvas id="cameraCanvas" style="max-width: 100%"></canvas>
@@ -16,11 +37,11 @@ Wish the web server handles route {/camera} with handler {
           setTimeout(advanceCamera, 0);
         };
         img.onerror = () => setTimeout(advanceCamera, 500);
-        img.src = '/camera-frame?uniq=' + Math.random();
+        img.src = '/camera-frame?camera=[string map {/ %2F} $camera]&uniq=' + Math.random();
       }
       advanceCamera();
     </script>
   </body>
 </html>
-    }
+    }]
 }

--- a/builtin-programs/web/camera.folk
+++ b/builtin-programs/web/camera.folk
@@ -2,7 +2,7 @@ Wish the web server handles route {/camera} with handler {
     if {[dict exists $QUERY camera]} {
         set camera [dict get $QUERY camera]
     } else {
-        set cameraResults [Query! /someone/ wishes $::thisNode uses camera /camera/ with /...any/]
+        set cameraResults [Query! camera /camera/ has width /w/ height /h/]
         if {[llength $cameraResults] == 1} {
             set camera [dict get [lindex $cameraResults 0] camera]
         } else {
@@ -12,7 +12,7 @@ Wish the web server handles route {/camera} with handler {
                 <p>Choose a camera:</p>
                 <ul>
                 [join [lmap result $cameraResults { subst {
-                    <li><a href="/camera?camera=[string map {/ %2F} $result(camera)]">$result(camera)</a></li>
+                    <li><a href="/camera?camera=[string map [list / %2F " " %20] $result(camera)]">$result(camera)</a></li>
                 } }] \n]
                 </ul>
                 </body>
@@ -43,7 +43,7 @@ Wish the web server handles route {/camera} with handler {
           setTimeout(advanceCamera, 0);
         };
         img.onerror = () => setTimeout(advanceCamera, 500);
-        img.src = '/camera-frame?camera=[string map {/ %2F} $camera]&uniq=' + Math.random();
+        img.src = '/camera-frame?camera=[string map [list / %2F " " %20] $camera]&uniq=' + Math.random();
       }
       advanceCamera();
 

--- a/builtin-programs/web/camera.folk
+++ b/builtin-programs/web/camera.folk
@@ -21,12 +21,17 @@ Wish the web server handles route {/camera} with handler {
         }
     }
 
+    # in case it's a virtual camera, we want to get the base path.
+    set baseCameraToControl [lindex $camera 0]
+
     html [subst {
 <html>
   <body style="margin: 0 0">
     <canvas id="cameraCanvas" style="max-width: 100%"></canvas>
     <div style="padding: 8px">
-      <strong>Adjust camera exposure:</strong>
+      <span id="status">Status</span>
+
+      <strong>Exposure:</strong>
       <input type="range" min="10" max="48" value="15" class="slider" id="camera-exposure-slider">
       <input type="number" min="1000" max="320000" step="100" value="1500" id="camera-exposure-number">μs
     </div>
@@ -47,16 +52,16 @@ Wish the web server handles route {/camera} with handler {
       }
       advanceCamera();
 
-      const ws = new FolkWS();
+      const ws = new FolkWS(document.getElementById('status'));
       const slider = document.getElementById('camera-exposure-slider');
       const numberInput = document.getElementById('camera-exposure-number');
 
       function updateExposure(valueInMicroseconds) {
         slider.value = valueInMicroseconds / 100;
         numberInput.value = valueInMicroseconds;
-        ws.hold('exposure', tcl`
-          Wish camera $camera uses exposure time \${valueInMicroseconds} us
-        `);
+        ws.hold('exposure $baseCameraToControl', tcl`
+          Wish camera $baseCameraToControl uses exposure time \${valueInMicroseconds} us
+        `, 'builtin-programs/web/setup.folk', true);
       }
 
       slider.addEventListener('input', (e) => updateExposure(Math.round(e.target.value * 100)));

--- a/builtin-programs/web/camera.folk
+++ b/builtin-programs/web/camera.folk
@@ -25,6 +25,12 @@ Wish the web server handles route {/camera} with handler {
 <html>
   <body style="margin: 0 0">
     <canvas id="cameraCanvas" style="max-width: 100%"></canvas>
+    <div style="padding: 8px">
+      <strong>Adjust camera exposure:</strong>
+      <input type="range" min="10" max="48" value="15" class="slider" id="camera-exposure-slider">
+      <input type="number" min="1000" max="320000" step="100" value="1500" id="camera-exposure-number">μs
+    </div>
+    <script src="/lib/folk.js"></script>
     <script>
       const canvas = cameraCanvas;
       const ctx = canvas.getContext('2d');
@@ -40,6 +46,21 @@ Wish the web server handles route {/camera} with handler {
         img.src = '/camera-frame?camera=[string map {/ %2F} $camera]&uniq=' + Math.random();
       }
       advanceCamera();
+
+      const ws = new FolkWS();
+      const slider = document.getElementById('camera-exposure-slider');
+      const numberInput = document.getElementById('camera-exposure-number');
+
+      function updateExposure(valueInMicroseconds) {
+        slider.value = valueInMicroseconds / 100;
+        numberInput.value = valueInMicroseconds;
+        ws.hold('exposure', tcl`
+          Wish camera $camera uses exposure time \${valueInMicroseconds} us
+        `);
+      }
+
+      slider.addEventListener('input', (e) => updateExposure(Math.round(e.target.value * 100)));
+      numberInput.addEventListener('input', (e) => updateExposure(parseInt(e.target.value)));
     </script>
   </body>
 </html>

--- a/builtin-programs/web/camera.folk
+++ b/builtin-programs/web/camera.folk
@@ -23,6 +23,12 @@ Wish the web server handles route {/camera} with handler {
 
     # in case it's a virtual camera, we want to get the base path.
     set baseCameraToControl [lindex $camera 0]
+    set exposuresAtPageLoad [Query! /someone/ wishes camera $baseCameraToControl uses exposure time /exposureTime/ us]
+    if {[llength $exposuresAtPageLoad] == 1} {
+        set exposureAtPageLoad [dict get [lindex $exposuresAtPageLoad 0] exposureTime]
+    } else {
+        set exposureAtPageLoad 1500
+    }
 
     html [subst {
 <html>
@@ -63,27 +69,29 @@ Wish the web server handles route {/camera} with handler {
         `, 'builtin-programs/web/setup.folk', true);
       }
 
-      function updateExposure(valueInMicroseconds) {
-        cameraExposureSlider.value = valueInMicroseconds / 100;
-        cameraExposureNumber.value = valueInMicroseconds;
-        sendExposure(valueInMicroseconds);
-      }
-
-      function applyAutoExposure() {
-        const auto = cameraAutoexposure.checked;
+      function updateExposure(valueInMicroseconds, doSend = true) {
+        const auto = valueInMicroseconds == 0;
+        cameraAutoexposure.checked = auto;
         cameraExposureSlider.disabled = auto;
         cameraExposureNumber.disabled = auto;
         manualExposure.style.opacity = auto ? 0.5 : 1;
-        if (auto) {
-          sendExposure(0);
-        } else {
-          sendExposure(parseInt(cameraExposureNumber.value));
+
+        if (!auto) {
+          cameraExposureSlider.value = valueInMicroseconds / 100;
+          cameraExposureNumber.value = valueInMicroseconds;
         }
+
+        if (doSend) { sendExposure(valueInMicroseconds); }
       }
 
       cameraExposureSlider.addEventListener('input', (e) => updateExposure(Math.round(e.target.value * 100)));
-      cameraExposureNumber.addEventListener('input', (e) => updateExposure(parseInt(e.target.value)));
-      cameraAutoexposure.addEventListener('change', applyAutoExposure);
+      cameraExposureNumber.addEventListener('input', (e) => {
+         let value = parseInt(e.target.value);
+         if (value == 0) value = 100; // just so people don't get stuck in auto.
+         updateExposure(value);
+      });
+      cameraAutoexposure.addEventListener('change', (e) => updateExposure(e.target.checked ? 0 : cameraExposureNumber.value));
+      updateExposure($exposureAtPageLoad, false)
     </script>
   </body>
 </html>

--- a/builtin-programs/web/camera.folk
+++ b/builtin-programs/web/camera.folk
@@ -29,11 +29,15 @@ Wish the web server handles route {/camera} with handler {
   <body style="margin: 0 0">
     <canvas id="cameraCanvas" style="max-width: 100%"></canvas>
     <div style="padding: 8px">
-      <span id="status">Status</span>
+      <span id="statusSpan">Status</span>
 
-      <strong>Exposure:</strong>
-      <input type="range" min="10" max="48" value="15" class="slider" id="camera-exposure-slider">
-      <input type="number" min="1000" max="320000" step="100" value="1500" id="camera-exposure-number">μs
+      <label><input type="checkbox" id="cameraAutoexposure">Auto-exposure</label>
+
+      <div style="display: inline-block" id="manualExposure">
+        Manual exposure:
+        <input style="max-width: 100px" type="range" min="10" max="48" value="15" class="slider" id="cameraExposureSlider">
+        <input type="number" min="1000" max="320000" step="100" value="1500" id="cameraExposureNumber">μs
+      </div>
     </div>
     <script src="/lib/folk.js"></script>
     <script>
@@ -52,20 +56,34 @@ Wish the web server handles route {/camera} with handler {
       }
       advanceCamera();
 
-      const ws = new FolkWS(document.getElementById('status'));
-      const slider = document.getElementById('camera-exposure-slider');
-      const numberInput = document.getElementById('camera-exposure-number');
-
-      function updateExposure(valueInMicroseconds) {
-        slider.value = valueInMicroseconds / 100;
-        numberInput.value = valueInMicroseconds;
+      const ws = new FolkWS(statusSpan);
+      function sendExposure(valueInMicroseconds) {
         ws.hold('exposure $baseCameraToControl', tcl`
           Wish camera $baseCameraToControl uses exposure time \${valueInMicroseconds} us
         `, 'builtin-programs/web/setup.folk', true);
       }
 
-      slider.addEventListener('input', (e) => updateExposure(Math.round(e.target.value * 100)));
-      numberInput.addEventListener('input', (e) => updateExposure(parseInt(e.target.value)));
+      function updateExposure(valueInMicroseconds) {
+        cameraExposureSlider.value = valueInMicroseconds / 100;
+        cameraExposureNumber.value = valueInMicroseconds;
+        sendExposure(valueInMicroseconds);
+      }
+
+      function applyAutoExposure() {
+        const auto = cameraAutoexposure.checked;
+        cameraExposureSlider.disabled = auto;
+        cameraExposureNumber.disabled = auto;
+        manualExposure.style.opacity = auto ? 0.5 : 1;
+        if (auto) {
+          sendExposure(0);
+        } else {
+          sendExposure(parseInt(cameraExposureNumber.value));
+        }
+      }
+
+      cameraExposureSlider.addEventListener('input', (e) => updateExposure(Math.round(e.target.value * 100)));
+      cameraExposureNumber.addEventListener('input', (e) => updateExposure(parseInt(e.target.value)));
+      cameraAutoexposure.addEventListener('change', applyAutoExposure);
     </script>
   </body>
 </html>

--- a/builtin-programs/web/index.folk
+++ b/builtin-programs/web/index.folk
@@ -14,8 +14,8 @@ Wish the web server handles route "/" with handler {
         lappend returnList "<ul>"
         foreach item $programList {
             set escapedThis [regsub -all -- / $item(programName) __]
-            set out [readOutputFile "/tmp/folk-[pid]/$escapedThis.stdout"]
-            set err [readOutputFile "/tmp/folk-[pid]/$escapedThis.stderr"]
+            set out [readOutputFile "/var/tmp/folk-[pid]/$escapedThis.stdout"]
+            set err [readOutputFile "/var/tmp/folk-[pid]/$escapedThis.stderr"]
             set outputHtml ""
             if {$out ne ""} {
                 append outputHtml "<pre style='margin: 0.25em 0 0 1em; padding: 0.25em 0.5em; font-size: 0.85em; white-space: pre-wrap; border-left: 3px solid #888'>[htmlEscape $out]</pre>"

--- a/builtin-programs/web/index.folk
+++ b/builtin-programs/web/index.folk
@@ -72,10 +72,10 @@ Wish the web server handles route "/" with handler {
         lappend vp {programName "sysmon.c"}
 
         return [join [list \
-            [emitHtmlForProgramList $rp "real-programs"] \
-            [emitHtmlForProgramList $wp "web-programs"] \
             [emitHtmlForProgramList $vp "builtin-programs"] \
-            [emitHtmlForProgramList $cp "local-programs"]]]
+            [emitHtmlForProgramList $cp "local-programs"] \
+            [emitHtmlForProgramList $rp "real-programs"] \
+            [emitHtmlForProgramList $wp "web-programs"] ]]
     }
 
     html [subst {

--- a/builtin-programs/web/quads.folk
+++ b/builtin-programs/web/quads.folk
@@ -256,7 +256,7 @@ Wish the web server handles route "/quads" with handler {
                 const ws = new FolkWS();
 
                 // Watch for camera space
-                ws.watchCollected("/someone/ wishes /node/ uses camera /camera/ with /...opts/",
+                ws.watchCollected("/someone/ claims camera /camera/ has width /w/ height /h/",
                     results => {
                         const newSpace = results[0]?.camera || null;
                         if (newSpace !== firstCameraSpace) {

--- a/builtin-programs/web/setup.folk
+++ b/builtin-programs/web/setup.folk
@@ -69,12 +69,7 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
 <div class="mode-select">
   <h2>Displays</h2>
   <div style="margin: 10px 0; border: 1px solid #ccc; padding: 10px;">
-    <label>
-      <input type="radio" name="display-enabled"
-             value=""
-             onchange="displayEnabledChange.call(this, event)">
-      <strong>Don't use a display</strong>
-    </label>
+    <button onclick="dontUseDisplay()"><strong>Don't use a display</strong></button>
   </div>
 
   [HtmlWhen $::thisNode has display /display/ with /...opts/ {
@@ -100,7 +95,7 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
     subst {
       <div style="margin: 10px 0; border: 1px solid #ccc; padding: 10px;">
         <label>
-          <input type="radio" name="display-enabled"
+          <input type="checkbox" name="display-enabled"
                  $($isUsingDisplay ? "checked" : "")
                  value="$display"
                  onchange="displayEnabledChange.call(this, event)">
@@ -148,18 +143,20 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
     }
   }}]
   <script>
+   function dontUseDisplay() {
+     document.querySelectorAll('input\[type="checkbox"\]\[name="display-enabled"]:checked').forEach(cb => {
+       cb.checked = false;
+       folk.hold(`display \${cb.value}`, '',
+                 'builtin-programs/web/setup.folk', true);
+     });
+   }
    function displayEnabledChange(event) {
      const display = this.value;
      if (this.checked) {
        if (display === "glfw") {
          // glfw doesn't have any mode settings (for now).
-         folk.hold('display', `Wish \$::thisNode uses display "\${display}" with width 640 height 480 refreshRate -1`,
+         folk.hold(`display \${display}`, `Wish \$::thisNode uses display "\${display}" with width 640 height 480 refreshRate -1`,
                    'builtin-programs/web/setup.folk', true);
-
-       } else if (display === "") {
-         folk.hold('display', '',
-                   'builtin-programs/web/setup.folk', true);
-
        } else {
          const firstRefreshRateRadio = document.querySelector(
            `input\[type="radio"\]\[name^="display-refreshRate-"\]\[data-display="\${display}"]`
@@ -168,7 +165,8 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
          firstRefreshRateRadio.dispatchEvent(new Event('change'));
        }
      } else {
-       // I think this never fires?
+       folk.hold(`display \${display}`, '',
+                 'builtin-programs/web/setup.folk', true);
      }
    }
    function displayResolutionClicked(event) {
@@ -185,7 +183,7 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
      if (this.checked) {
        const display = this.dataset.display;
        const mode = this.value;
-       folk.hold('display', `Wish \$::thisNode uses display "\${display}" with \${mode}`,
+       folk.hold(`display \${display}`, `Wish \$::thisNode uses display "\${display}" with \${mode}`,
                  'builtin-programs/web/setup.folk', true);
      }
      event.preventDefault();

--- a/builtin-programs/web/setup.folk
+++ b/builtin-programs/web/setup.folk
@@ -146,11 +146,18 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
    function dontUseDisplay() {
      document.querySelectorAll('input\[type="checkbox"\]\[name="display-enabled"]:checked').forEach(cb => {
        cb.checked = false;
+
+       // HACK: remove older-form display setup.
+       folk.hold(`display`, '', 'builtin-programs/web/setup.folk', true);
+
        folk.hold(`display \${cb.value}`, '',
                  'builtin-programs/web/setup.folk', true);
      });
    }
    function displayEnabledChange(event) {
+     // HACK: remove older-form display setup.
+     folk.hold(`display`, '', 'builtin-programs/web/setup.folk', true);
+
      const display = this.value;
      if (this.checked) {
        if (display === "glfw") {

--- a/builtin-programs/web/setup.folk
+++ b/builtin-programs/web/setup.folk
@@ -273,7 +273,7 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
         
         [if {$isUsingCamera} {
           set iframeWidth 600
-          set iframeHeight [expr {int(600.0 * $usingOpts(height) / $usingOpts(width))}]
+          set iframeHeight [expr {int(600.0 * $usingOpts(height) / $usingOpts(width)) + 48}]
           subst {
           <div style="margin-top: 10px;">
             <iframe src="/camera?camera=[string map {/ %2F} $camera]"

--- a/builtin-programs/web/setup.folk
+++ b/builtin-programs/web/setup.folk
@@ -198,6 +198,28 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
   </script>
 </div>
 
+<style>
+  .crop-box {
+      position: absolute;
+      border: 2px solid #27ae60;
+      background: rgba(39,174,96,0.15);
+      box-sizing: border-box;
+      pointer-events: auto;
+      cursor: move;
+  }
+  .crop-handle {
+      position: absolute;
+      width: 12px; height: 12px;
+      background: white;
+      border: 2px solid #27ae60;
+      box-sizing: border-box;
+      pointer-events: auto;
+  }
+  .crop-handle\[data-corner="nw"] { top: -7px; left: -7px; cursor: nwse-resize; }
+  .crop-handle\[data-corner="ne"] { top: -7px; right: -7px; cursor: nesw-resize; }
+  .crop-handle\[data-corner="sw"] { bottom: -7px; left: -7px; cursor: nesw-resize; }
+  .crop-handle\[data-corner="se"] { bottom: -7px; right: -7px; cursor: nwse-resize; }
+</style>
 <div class="mode-select">
   <h2>Cameras</h2>
   [HtmlWhen $::thisNode has camera /camera/ with /...opts/ {
@@ -273,12 +295,50 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
         
         [if {$isUsingCamera} {
           set iframeWidth 600
-          set iframeHeight [expr {int(600.0 * $usingOpts(height) / $usingOpts(width)) + 48}]
+          set cameraAreaHeight [expr {int(600.0 * $usingOpts(height) / $usingOpts(width))}]
+          set iframeHeight [expr {$cameraAreaHeight + 48}]
+          set existingCrops [dict getdef $usingOpts crops [list]]
           subst {
-          <div style="margin-top: 10px;">
+          <div class="camera-preview" data-camera="$camera"
+               style="position: relative; display: inline-block; margin-top: 10px; line-height: 0;">
             <iframe src="/camera?camera=[string map {/ %2F} $camera]"
                     width="$iframeWidth" height="$iframeHeight"
-                    style="border: 1px solid #999;"></iframe>
+                    style="border: 1px solid #999; display: block;"></iframe>
+            <div class="crop-overlay"
+                 style="position: absolute; top: 1px; left: 1px;
+                        width: ${iframeWidth}px; height: ${cameraAreaHeight}px;
+                        pointer-events: none;">
+              <!-- [set i 0] -->
+              [join [lmap c $existingCrops {
+                set cx [dict get $c x]
+                set cy [dict get $c y]
+                set cw [dict get $c width]
+                set ch [dict get $c height]
+                set rx [expr {int($cx * $iframeWidth / $usingOpts(width))}]
+                set ry [expr {int($cy * $cameraAreaHeight / $usingOpts(height))}]
+                set rw [expr {int($cw * $iframeWidth / $usingOpts(width))}]
+                set rh [expr {int($ch * $cameraAreaHeight / $usingOpts(height))}]
+                set cropHtml [subst {
+                  <div class="crop-box" data-index="$i" data-crop="$cx,$cy,$cw,$ch"
+                       style="left: ${rx}px; top: ${ry}px;
+                              width: ${rw}px; height: ${rh}px;">
+                    <div class="crop-handle" data-corner="nw"></div>
+                    <div class="crop-handle" data-corner="ne"></div>
+                    <div class="crop-handle" data-corner="sw"></div>
+                    <div class="crop-handle" data-corner="se"></div>
+                  </div>
+                }]
+                incr i
+                set cropHtml
+              }] \n]
+            </div>
+          </div>
+
+          <div style="margin-top: 10px;">
+            <button data-camera="$camera"
+                    onclick="createVirtualCroppedCamera.call(this, event)">
+              Create virtual cropped camera
+            </button>
           </div>
         } }]
       </div>
@@ -319,6 +379,134 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
       }
       event.preventDefault();
     }
+    const CROP_MCU = 16;
+    const snap = v => Math.floor(v / CROP_MCU) * CROP_MCU;
+
+    function getCropContext(el) {
+      const preview = el.closest('.camera-preview');
+      if (!preview) return null;
+      const camera = preview.dataset.camera;
+      const iframe = preview.querySelector('iframe');
+      const overlay = preview.querySelector('.crop-overlay');
+      const framerateRadio = document.querySelector(
+        `input\[type="radio"\]\[name^="camera-framerate-"\]\[data-camera="\${camera}"]:checked`);
+      if (!framerateRadio) return null;
+      const format = framerateRadio.value;
+      const m = format.match(/width (\\d+) height (\\d+)/);
+      if (!m) return null;
+      return {
+        camera, preview, iframe, overlay, format,
+        sourceWidth: parseInt(m\[1]),
+        sourceHeight: parseInt(m\[2]),
+        iframeWidth: parseInt(iframe.width),
+        canvasHeight: parseInt(iframe.height) - 48,
+      };
+    }
+
+    function issueCrops(ctx, crops) {
+      const cropsTcl = crops
+        .map((\[x,y,w,h]) => `{x \${x} y \${y} width \${w} height \${h}}`)
+        .join(' ');
+      folk.hold(`camera \${ctx.camera}`,
+        `Wish \$::thisNode uses camera "\${ctx.camera}" with \${ctx.format} crops {\${cropsTcl}}`,
+        'builtin-programs/web/setup.folk', true);
+    }
+
+    function readCrops(overlay) {
+      return Array.from(overlay.querySelectorAll('.crop-box'))
+        .map(el => el.dataset.crop.split(',').map(Number));
+    }
+
+    function applyBoxStyle(ctx, box, x, y, w, h) {
+      box.style.left = (x * ctx.iframeWidth / ctx.sourceWidth) + 'px';
+      box.style.top = (y * ctx.canvasHeight / ctx.sourceHeight) + 'px';
+      box.style.width = (w * ctx.iframeWidth / ctx.sourceWidth) + 'px';
+      box.style.height = (h * ctx.canvasHeight / ctx.sourceHeight) + 'px';
+    }
+
+    function createVirtualCroppedCamera(event) {
+      const ctx = getCropContext(this);
+      if (!ctx) return;
+      // Default: ~1/3 of source, centered, MCU-aligned.
+      const w = Math.max(CROP_MCU, snap(ctx.sourceWidth / 3));
+      const h = Math.max(CROP_MCU, snap(ctx.sourceHeight / 3));
+      const x = snap((ctx.sourceWidth - w) / 2);
+      const y = snap((ctx.sourceHeight - h) / 2);
+      const crops = readCrops(ctx.overlay);
+      crops.push(\[x, y, w, h]);
+      issueCrops(ctx, crops);
+      event.preventDefault();
+    }
+
+    // Drag to move (crop-box body) or resize (crop-handle corners).
+    // During drag the overlay flips to pointer-events: auto so the iframe
+    // underneath doesn't steal mousemove events when the cursor passes
+    // over it.
+    let cropDrag = null;
+    document.addEventListener('mousedown', e => {
+      const handle = e.target.closest('.crop-handle');
+      const box = e.target.closest('.crop-box');
+      if (!box) return;
+      const ctx = getCropContext(box);
+      if (!ctx) return;
+      const \[x0, y0, w0, h0] = box.dataset.crop.split(',').map(Number);
+      const mode = handle ? 'resize' : 'move';
+      const corner = handle ? handle.dataset.corner : null;
+      cropDrag = {
+        ctx, box, mode, corner,
+        sx: e.clientX, sy: e.clientY,
+        x0, y0, w0, h0,
+        live: null,
+      };
+      ctx.overlay.style.pointerEvents = 'auto';
+      document.body.style.cursor = mode === 'move' ? 'move'
+        : (corner === 'nw' || corner === 'se') ? 'nwse-resize'
+        : 'nesw-resize';
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    document.addEventListener('mousemove', e => {
+      const d = cropDrag;
+      if (!d) return;
+      const dx = (e.clientX - d.sx) * (d.ctx.sourceWidth / d.ctx.iframeWidth);
+      const dy = (e.clientY - d.sy) * (d.ctx.sourceHeight / d.ctx.canvasHeight);
+      let x, y, w, h;
+      if (d.mode === 'move') {
+        x = Math.max(0, Math.min(d.ctx.sourceWidth - d.w0, snap(d.x0 + dx)));
+        y = Math.max(0, Math.min(d.ctx.sourceHeight - d.h0, snap(d.y0 + dy)));
+        w = d.w0; h = d.h0;
+      } else {
+        let left = d.x0, top = d.y0;
+        let right = d.x0 + d.w0, bottom = d.y0 + d.h0;
+        if (d.corner.includes('w')) {
+          left = Math.max(0, Math.min(right - CROP_MCU, snap(d.x0 + dx)));
+        }
+        if (d.corner.includes('e')) {
+          right = Math.max(left + CROP_MCU,
+                           Math.min(d.ctx.sourceWidth, snap(d.x0 + d.w0 + dx)));
+        }
+        if (d.corner.includes('n')) {
+          top = Math.max(0, Math.min(bottom - CROP_MCU, snap(d.y0 + dy)));
+        }
+        if (d.corner.includes('s')) {
+          bottom = Math.max(top + CROP_MCU,
+                            Math.min(d.ctx.sourceHeight, snap(d.y0 + d.h0 + dy)));
+        }
+        x = left; y = top; w = right - left; h = bottom - top;
+      }
+      d.live = \[x, y, w, h];
+      applyBoxStyle(d.ctx, d.box, x, y, w, h);
+    });
+    document.addEventListener('mouseup', () => {
+      const d = cropDrag;
+      if (!d) return;
+      cropDrag = null;
+      d.ctx.overlay.style.pointerEvents = '';
+      document.body.style.cursor = '';
+      if (!d.live) return;
+      d.box.dataset.crop = d.live.join(',');
+      issueCrops(d.ctx, readCrops(d.ctx.overlay));
+    });
   </script>
 </div>
 
@@ -344,7 +532,7 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
 
   <fieldset style="margin: 10px 0; border: 1px solid #ccc; padding: 10px;">
     <legend><strong>Cameras</strong></legend>
-    [HtmlWhen /someone/ wishes $::thisNode uses camera /camera/ with /...opts/ {
+    <!-- [local proc emitCameraHtml {camera} {
       subst {
         <div style="margin: 5px 0;">
           <label>
@@ -355,6 +543,17 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
           </label>
         </div>
       }
+    }] -->
+    [HtmlWhen /someone/ wishes $::thisNode uses camera /camera/ with /...opts/ {
+        if {[dict exists $opts crops]} {
+            set htmls [list]
+            loop i [llength $opts(crops)] {
+                lappend htmls [emitCameraHtml [list $camera $i]]
+            }
+            join $htmls \n
+        } else {
+            emitCameraHtml $camera
+        }
     }]
   </fieldset>
 

--- a/builtin-programs/web/setup.folk
+++ b/builtin-programs/web/setup.folk
@@ -383,9 +383,12 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
     const snap = v => Math.floor(v / CROP_MCU) * CROP_MCU;
 
     function getCropContext(el) {
-      const preview = el.closest('.camera-preview');
-      if (!preview) return null;
-      const camera = preview.dataset.camera;
+      let preview = el.closest('.camera-preview');
+      const camera = preview ? preview.dataset.camera : el.dataset.camera;;
+      if (!preview) {
+        preview = document.querySelector(`.camera-preview\[data-camera="\${camera}"]`);
+      }
+
       const iframe = preview.querySelector('iframe');
       const overlay = preview.querySelector('.crop-overlay');
       const framerateRadio = document.querySelector(
@@ -532,7 +535,7 @@ folk.watchCollected(`/someone/ wishes the web server handles route "/setup" with
 
   <fieldset style="margin: 10px 0; border: 1px solid #ccc; padding: 10px;">
     <legend><strong>Cameras</strong></legend>
-    <!-- [local proc emitCameraHtml {camera} {
+    <!-- [fn emitCameraHtml {camera} {
       subst {
         <div style="margin: 5px 0;">
           <label>

--- a/builtin-programs/web/textures.folk
+++ b/builtin-programs/web/textures.folk
@@ -1,7 +1,7 @@
 When the GPU library is /gpuLib/ & the image library is /imageLib/ &\
      the GPU draw library is /drawLib/ &\
      the GPU VMA DLL is /vmaDll/ &\
-     the GPU texture library for /drawLib/ is /gpuTextureLib/ &\
+     the GPU texture library is /gpuTextureLib/ &\
      display /any/ has width /any/ height /any/ {
     set cc [C]
     $cc endcflags -lpng

--- a/builtin-programs/web/textures.folk
+++ b/builtin-programs/web/textures.folk
@@ -1,8 +1,7 @@
 When the GPU library is /gpuLib/ & the image library is /imageLib/ &\
      the GPU draw library is /drawLib/ &\
      the GPU VMA DLL is /vmaDll/ &\
-     the GPU texture library is /gpuTextureLib/ &\
-     display /any/ has width /any/ height /any/ {
+     the GPU texture library is /gpuTextureLib/ {
     set cc [C]
     $cc endcflags -lpng
     $cc cflags -I./vendor

--- a/builtin-programs/web/web.folk
+++ b/builtin-programs/web/web.folk
@@ -298,7 +298,7 @@ vwait forever
 
 } on error {e opts} {
     puts $::realStderr "WARNING: web.folk failed to initialize;
-the web server is probably down; check /tmp/folk-[pid]/ for log files.
+the web server is probably down; check /var/tmp/folk-[pid]/ for log files.
 (Make sure libtool and autoconf-archive are installed.)
 ------------------------------------------
 [errorInfo $e]"

--- a/builtin-programs/web/web.folk
+++ b/builtin-programs/web/web.folk
@@ -283,6 +283,7 @@ proc handleRead {chan addr} {
 while true {
     try {
         set f [socket stream.server 4273]
+        $f listen 128
         $f readable [lambda {} {f} {
             set client [$f accept addr]
             handleConnect $client $addr

--- a/builtin-programs/web/web.folk
+++ b/builtin-programs/web/web.folk
@@ -8,7 +8,6 @@ puts "web: [__threadId] (PID [pid])"
 signal handle SIGPIPE
 
 # To force a rebuild: rm vendor/wslay/Makefile
-set wslayFresh [expr {![file exists vendor/wslay/lib/.libs/libwslay.a]}]
 if {![file exists vendor/wslay/Makefile]} {
     puts "web: Configuring libwslay..."
     exec sh -c {cd vendor/wslay && autoreconf -i && automake && autoconf && ./configure} \
@@ -16,10 +15,6 @@ if {![file exists vendor/wslay/Makefile]} {
 }
 puts "web: Building libwslay..."
 exec make -C vendor/wslay >@stdout 2>@stderr
-if {$wslayFresh && $::tcl_platform(os) eq "linux"} {
-    exec patchelf --set-soname "[pwd]/vendor/wslay/lib/.libs/libwslay.so.0" \
-        vendor/wslay/lib/.libs/libwslay.so.0
-}
 puts "web: libwslay built."
 
 source "lib/ws.tcl"

--- a/lib/c.tcl
+++ b/lib/c.tcl
@@ -285,7 +285,7 @@ C method include {h} {
     }
 }
 
-C method code {newcode} {
+C method code {newcode {extendArg {:noextend}}} {
     lassign [info source $newcode] filename line
     if {$filename ne ""} { 
         set newcode [subst {
@@ -293,7 +293,7 @@ C method code {newcode} {
             $newcode
         }]
     }
-    lappend code $newcode :noextend
+    lappend code $newcode {*}$extendArg
     list
 }
 

--- a/lib/c.tcl
+++ b/lib/c.tcl
@@ -753,7 +753,7 @@ extern "C" \{
     while {![file exists /tmp/$cid.so]} {
         sleep 0.01
         incr n
-        if {$n > 10} { error "Failed! [string range $e 0 500]" }
+        if {$n > 200} { error "Failed on /tmp/$cid.so! Timed out" }
     }
 
     if {$noload} {

--- a/output-redirection.c
+++ b/output-redirection.c
@@ -150,21 +150,26 @@ static char outputDir[256];
 void outputRedirectionInit(void) {
     sh_new_arena(programFdsTable);
 
-    snprintf(outputDir, sizeof(outputDir), "/tmp/folk-%d", (int)getpid());
+    snprintf(outputDir, sizeof(outputDir), "/var/tmp/folk-%d", (int)getpid());
     mkdir(outputDir, 0755);
 
     // Save stdout and stderr once, globally.
     realStdout = dup(1);
     realStderr = dup(2);
 
-    // Redirect fd 1/2 to /dev/null so system frameworks (NSLog,
-    // AppKit, etc.)  see a non-TTY and suppress their stderr
+    // Redirect fd 1/2 to OTHER.stdout/stderr so system frameworks
+    // (NSLog, AppKit, etc.) see a non-TTY and suppress their stderr
     // output. All legitimate writes go through folk_interpose.dylib
     // -> folkGetFdOverride, or to realStdout/realStderr.
-    int devnull = open("/dev/null", O_WRONLY);
-    dup2(devnull, STDOUT_FILENO);
-    dup2(devnull, STDERR_FILENO);
-    close(devnull);
+    char path[4096];
+    snprintf(path, sizeof(path), "%s/OTHER.stdout", outputDir);
+    int otherStdout = open(path, O_WRONLY | O_CREAT | O_APPEND, 0644);
+    snprintf(path, sizeof(path), "%s/OTHER.stderr", outputDir);
+    int otherStderr = open(path, O_WRONLY | O_CREAT | O_APPEND, 0644);
+    dup2(otherStdout, STDOUT_FILENO);
+    dup2(otherStderr, STDERR_FILENO);
+    close(otherStdout);
+    close(otherStderr);
 }
 
 void installLocalStdoutAndStderr(int stdoutfd, int stderrfd) {

--- a/sysmon.c
+++ b/sysmon.c
@@ -265,9 +265,9 @@ void *sysmonMain(void *ptr) {
 
     {
         char path[256];
-        snprintf(path, sizeof(path), "/tmp/folk-%d/sysmon.c.stdout", getpid());
+        snprintf(path, sizeof(path), "/var/tmp/folk-%d/sysmon.c.stdout", getpid());
         int outfd = open(path, O_WRONLY | O_CREAT | O_APPEND, 0644);
-        snprintf(path, sizeof(path), "/tmp/folk-%d/sysmon.c.stderr", getpid());
+        snprintf(path, sizeof(path), "/var/tmp/folk-%d/sysmon.c.stderr", getpid());
         int errfd = open(path, O_WRONLY | O_CREAT | O_APPEND, 0644);
         installLocalStdoutAndStderr(outfd, errfd);
     }


### PR DESCRIPTION
This is only about half of the refactor that's needed -- we still can't actually _draw_ different stuff on the different displays. All displays show the same thing.

Most of the change here is just moving code around so that the draw library isn't tightly coupled to the specific display mode (and therefore to a specific display) and we can run the same draw logic on multiple displays.

Multiple cameras are also supported (and have been for a while, I think), although I haven't tested having multiple calibrations in play right now. They should all be able to recognize tags, at least.

This branch is big enough and stable enough (and comes with enough nice-to-have changes to build on for calibration improvements, etc) that I want to get it tested and merged before proceeding.

Smaller changes:
- Moves exposure control into /camera and uses /camera in the calibrate web page. Persists exposure setting.
  - <img width="500" alt="image" src="https://github.com/user-attachments/assets/4b4eb9df-bbe0-4e24-a136-2203ded701e3" />
- Has camera auto-restart if it fails
- (only half-finished, but should work) Can crop camera into a 'virtual camera' from the web ui. Useful for ELP stereo camera (breaks compatibility with old `crop` setting)
- Put logs in /var/tmp/folk-PID instead of /tmp/folk-PID so they survive PC reboot
- Disables FORTIFY_SOURCE for Folk kernel so that output redirection works from it
- Redirect any missed stdout/stderr to OTHER.stdout and OTHER.stderr (Vulkan validation, macOS framework complaints, other library output that we can't catch)
- Texture upload ring so that texture upload is async and doesn't block caller of copyImageToGpu for 5-10ms every time -- I'm not that confident in this code but it does help latency and doesn't seem to do any harm, please look at this if you can