### PR TITLE
Fix footnotes, right/left-margins

### DIFF
--- a/builtin-programs/title.folk
+++ b/builtin-programs/title.folk
@@ -1,6 +1,9 @@
 # Title/footnote wish fulfillment
 # for wishes of the form:
-# "Wish $tag is titled "This is a tag"" or "Wish $tag is footnoted "This is a footnote""
+# Wish $this is titled "This is a tag"
+# Wish $this is footnoted "This is a footnote"
+# Wish $this is right-margined "This is right-margined text"
+# Wish $this is left-margined "This is left-margined text"
 
 When /thing/ has quad /quad/ {
     Claim -keep 50ms $thing has a quad
@@ -15,64 +18,63 @@ When the quad library is /quadLib/ &\
 
     fn quadChange
 
-    When the collected results for [list /someone/ wishes $thing is titled /text/] are /results/ {
-        set text [join [lmap result $results {dict get $result text}] "\n"]
-        if {$text eq ""} { return }
-    
-        When -atomically $thing has quad /q/ {
-            # HACK: This is just direct working with pixels, like
-            # points-at, and it's ugly.
+    foreach {label edge textAnchor} {
+        titled         top    bottom
+        footnoted      bottom top
+        right-margined right  left
+        left-margined  left   right
+    } {
+        When the collected results for [list /someone/ wishes $thing is $label /text/] are /results/ {
+            set text [join [lmap result $results {dict get $result text}] "\n"]
+            if {$text eq ""} { return }
 
-            lassign [$quadLib vertices [quadChange $q "display $disp"]] \
-                topLeft topRight
+            When -atomically $thing has quad /q/ {
+                package require linalg
+                namespace import \
+                    ::math::linearalgebra::add \
+                    ::math::linearalgebra::sub \
+                    ::math::linearalgebra::scale \
+                    ::math::linearalgebra::unitLengthVector
 
-            set dispTopLeft [$poseLib project $displayIntrinsics \
-                                 $displayWidth $displayHeight $topLeft]
-            set dispTopRight [$poseLib project $displayIntrinsics \
-                                 $displayWidth $displayHeight $topRight]
-            set dispTopCenter [vec2 midpoint $dispTopLeft $dispTopRight]
-            set dispTop [vec2 sub $dispTopRight $dispTopLeft]
-            set dispRadians [expr {-atan2([lindex $dispTop 1], [lindex $dispTop 0])}]
-            Wish to draw text onto $disp with \
-                position $dispTopCenter \
-                scale 36.0 radians $dispRadians anchor bottom \
-                text $text
-        }
-    }
+                lassign [$quadLib vertices [quadChange $q "display $disp"]] \
+                    topLeft topRight bottomRight bottomLeft
 
-    When the collected results for [list /someone/ wishes $thing is footnoted /text/] are /results/ {
-        set text [join [lmap result $results {dict get $result text}] "\n"]
-        if {$text eq ""} { return }
+                switch $edge {
+                    top { 
+                        set physicalPos [scale 0.5 [add $topLeft $topRight]]
+                        set physicalDir [sub $topLeft $bottomLeft]
+                    }
+                    bottom { 
+                        set physicalPos [scale 0.5 [add $bottomLeft $bottomRight]]
+                        set physicalDir [sub $bottomLeft $topLeft]
+                    }
+                    right { 
+                        set physicalPos [scale 0.5 [add $topRight $bottomRight]]
+                        set physicalDir [sub $topRight $topLeft]
+                    }
+                    left { 
+                        set physicalPos [scale 0.5 [add $topLeft $bottomLeft]]
+                        set physicalDir [sub $topLeft $topRight]
+                    }
+                }
 
-        set radians [region angle $region]
-        When $thing has region /region/ {
-            set scale [dict getdef $result scale 0.75]
-            set pos [region bottomleft [region move $region down 20px]]
-            Wish to draw text with position $pos scale $scale text $text radians $radians anchor topleft
-        }
-    }
-    
-    When the collected results for [list /someone/ wishes $thing is right-margined /text/] are /results/ {
-        set text [join [lmap result $results {dict get $result text}] "\n"]
-        if {$text eq ""} { return }
+                set paddingMeters 0.02
+                set offset [scale $paddingMeters [unitLengthVector $physicalDir]]
+                set physicalPos [add $physicalPos $offset]
 
-        set radians [region angle $region]
-        When $thing has region /region/ {
-            set scale [dict getdef $result scale 0.75]
-            set pos [region right [region move $region right 10px]]
-            Wish to draw text with position $pos scale $scale text $text radians $radians anchor left
-        }
-    }
+                set dispPosition [$poseLib project $displayIntrinsics $displayWidth $displayHeight $physicalPos]
 
-    When the collected results for [list /someone/ wishes $thing is left-margined /text/] are /results/ {
-        set text [join [lmap result $results {dict get $result text}] "\n"]
-        if {$text eq ""} { return }
+                set dispTopLeft [$poseLib project $displayIntrinsics $displayWidth $displayHeight $topLeft]
+                set dispTopRight [$poseLib project $displayIntrinsics $displayWidth $displayHeight $topRight]
+                
+                set dispTop [vec2 sub $dispTopRight $dispTopLeft]
+                set dispRadians [expr {-atan2([lindex $dispTop 1], [lindex $dispTop 0])}]
 
-        set radians [region angle $region]
-        When $thing has region /region/ {
-            set scale [dict getdef $result scale 0.75]
-            set pos [region left [region move $region left 10px]]
-            Wish to draw text with position $pos scale $scale text $text radians $radians anchor right
+                Wish to draw text onto $disp with \
+                    position $dispPosition \
+                    scale 36.0 radians $dispRadians anchor $textAnchor \
+                    text $text
+            }
         }
     }
 }


### PR DESCRIPTION
1. Restoring `Wish $tag is footnoted/right-margined/left-margined`
2. Refactor so we're using physical coordinates to calculate

For example:

```tcl
When the clock time is /t/ {
  set formattedTime [clock format [clock seconds] -format "%I:%M:%S %p"]
  Wish $this is titled $formattedTime
  Wish $this is footnoted $formattedTime
  Wish $this is right-margined $formattedTime
  Wish $this is left-margined $formattedTime
}

Wish $this is outlined green
```

looks like:
<img width="50%" alt="four sided text labels on green square" src="https://github.com/user-attachments/assets/4eb5df87-5abf-45e7-9376-d2d57fbd990b" />

