### PR TITLE
Fix masking tags using quad library

### DIFF
--- a/builtin-programs/mask-tags.folk
+++ b/builtin-programs/mask-tags.folk
@@ -1,27 +1,20 @@
-# TODO: Fix this
-return
-
-When display /proj/ has width /projWidth/ height /projHeight/ &\
+When the quad library is /quadLib/ &\
+     the pose library is /poseLib/ &\
+     the quad changer is /quadChange/ &\
+     display /proj/ has width /projWidth/ height /projHeight/ &\
      display /proj/ has intrinsics /projectorIntrinsics/ {
         
-    When tag /id/ has quad /q/ {
-        # Convert quad to projector coordinates:
-        set tagCorners [lmap v [quad vertices [quad change $q "display $proj"]] {
-            intrinsics project $projectorIntrinsics \
-                $projWidth $projHeight $v
-        }]
+    fn quadChange
 
-        set vecBottom [sub [lindex $tagCorners 1] [lindex $tagCorners 0]]
-        set vecRight [sub [lindex $tagCorners 2] [lindex $tagCorners 1]]
+    When -atomically tag /id/ has quad /q/ {
+        set scaledQuad [$quadLib scale $q 2.25]
 
-        set offsets {{-0.5 -0.5} {0.5 -0.5} {0.5 0.5} {-0.5 0.5}}
-        set scales [matmul $offsets [list $vecBottom $vecRight]]
-        set corners [add $tagCorners $scales]
+        lassign [lmap v [$quadLib vertices [quadChange $scaledQuad "display $proj"]] {
+            $poseLib project $projectorIntrinsics $projWidth $projHeight $v
+        }] p0 p1 p2 p3
 
-        set p0 [lindex $corners 0]
-        set p1 [lindex $corners 1]
-        set p2 [lindex $corners 2]
-        set p3 [lindex $corners 3]
-        Wish to draw a quad with p0 $p0 p1 $p1 p2 $p2 p3 $p3 color black layer 1
+        Wish to draw a quad onto $proj with \
+            p0 $p0 p1 $p1 p2 $p2 p3 $p3 \
+            color black layer 99
     }
 }


### PR DESCRIPTION
Use the quad library to restore mask tagging

---

<img width="50%" alt="IMG_5377" src="https://github.com/user-attachments/assets/a04482e5-a6c1-4c18-a597-fd9d2be969e8" />