### PR TITLE
Fix silent shape errors

### DIFF
--- a/builtin-programs/draw/shapes.folk
+++ b/builtin-programs/draw/shapes.folk
@@ -167,159 +167,179 @@ fn drawShapePathPoints {points geom options} {
     return $transformed
 }
 
-When /someone/ wishes /p/ draws a /shape/ with /...options/ &\
+When /wisher/ wishes /p/ draws a /shape/ with /...options/ &\
      /p/ has resolved geometry /geom/ {
-    if {![info exists options]} { return }
-    set shape [drawShapeCanonical $shape $options]
-    set center [drawShapePosition $options $geom]
-    set color [dict getdef $options color white]
-    set filled [dict getdef $options filled false]
-    set geomWidth [dict get $geom width]
-    set geomHeight [dict get $geom height]
-    set thickness [drawShapeLengthOption $options thickness 0.002 \
-        $geomWidth $geomHeight min]
-    set layer [dict getdef $options layer 1]
-    set radians [drawShapeRadians $options]
-
-    if {$shape eq "circle"} {
-        set radius [drawShapeRadius $options 0.025 $geomWidth $geomHeight]
-        Wish to draw a circle onto $p with \
-            center $center radius $radius thickness $thickness \
-            color $color filled $filled layer $layer
-        return
-    }
-
-    if {$shape eq "rect"} {
-        set radius [drawShapeRadius $options 0.025 $geomWidth $geomHeight]
-        set size [drawShapeLengthOption $options size [expr {$radius * 2.0}] \
+    try {
+        if {![info exists options]} { return }
+        set shape [drawShapeCanonical $shape $options]
+        set center [drawShapePosition $options $geom]
+        set color [dict getdef $options color white]
+        set filled [dict getdef $options filled false]
+        set geomWidth [dict get $geom width]
+        set geomHeight [dict get $geom height]
+        set thickness [drawShapeLengthOption $options thickness 0.002 \
             $geomWidth $geomHeight min]
-        set rectWidth [drawShapeLengthOption $options width $size \
-            $geomWidth $geomHeight width]
-        set rectHeight [drawShapeLengthOption $options height $rectWidth \
-            $geomWidth $geomHeight height]
-        set points [drawShapeRectPoints $center $rectWidth $rectHeight $radians]
-    } else {
-        if {$shape eq "polygon" || $shape eq "polyline"} { return }
-        
-        if {[dict exists $options sides]} {
-            set sides [dict get $options sides]
-        } elseif {[dict exists $drawShapeSides $shape]} {
-            set sides [dict get $drawShapeSides $shape]
-        } else {
-            error "draw/shapes: unknown shape $shape"
-        }
-        set radius [drawShapeRadius $options 0.025 $geomWidth $geomHeight]
-        set points [drawShapeRegularPolygon $center $radius $sides $radians]
-    }
+        set layer [dict getdef $options layer 1]
+        set radians [drawShapeRadians $options]
 
-    if {$filled} {
-        Wish to draw a polygon onto $p with points $points color $color layer $layer
-    } else {
-        lappend points [lindex $points 0]
-        Wish to draw a line onto $p with \
-            points $points width $thickness color $color layer $layer
+        if {$shape eq "circle"} {
+            set radius [drawShapeRadius $options 0.025 $geomWidth $geomHeight]
+            Wish to draw a circle onto $p with \
+                center $center radius $radius thickness $thickness \
+                color $color filled $filled layer $layer
+            return
+        }
+
+        if {$shape eq "rect"} {
+            set radius [drawShapeRadius $options 0.025 $geomWidth $geomHeight]
+            set size [drawShapeLengthOption $options size [expr {$radius * 2.0}] \
+                $geomWidth $geomHeight min]
+            set rectWidth [drawShapeLengthOption $options width $size \
+                $geomWidth $geomHeight width]
+            set rectHeight [drawShapeLengthOption $options height $rectWidth \
+                $geomWidth $geomHeight height]
+            set points [drawShapeRectPoints $center $rectWidth $rectHeight $radians]
+        } else {
+            if {$shape eq "polygon" || $shape eq "polyline"} { return }
+            
+            if {[dict exists $options sides]} {
+                set sides [dict get $options sides]
+            } elseif {[dict exists $drawShapeSides $shape]} {
+                set sides [dict get $drawShapeSides $shape]
+            } else {
+                error "draw/shapes: unknown shape $shape"
+            }
+            set radius [drawShapeRadius $options 0.025 $geomWidth $geomHeight]
+            set points [drawShapeRegularPolygon $center $radius $sides $radians]
+        }
+
+        if {$filled} {
+            Wish to draw a polygon onto $p with points $points color $color layer $layer
+        } else {
+            lappend points [lindex $points 0]
+            Wish to draw a line onto $p with \
+                points $points width $thickness color $color layer $layer
+        }
+    } on error {err opts} {
+        Say $wisher has error $err with info $opts
     }
 }
 
-When /someone/ wishes /p/ draws a /shape/ {
+When /wisher/ wishes /p/ draws a /shape/ {
     Wish $p draws a $shape with color white filled true
 }
 
-When /someone/ wishes /p/ draws text /text/ with /...options/ &\
+When /wisher/ wishes /p/ draws text /text/ with /...options/ &\
      /p/ has resolved geometry /geom/ {
-    if {![info exists options]} { return }
-    set position [drawShapePosition $options $geom]
-    set color [dict getdef $options color white]
-    set scale [drawShapeLengthOption $options scale 0.01 \
-        [dict get $geom width] [dict get $geom height] min]
-    set layer [dict getdef $options layer 0]
-    set anchor [dict getdef $options anchor center]
-    set font [dict getdef $options font "PTSans-Regular"]
-    set radians [drawShapeRadians $options]
+    try {
+        if {![info exists options]} { return }
+        set position [drawShapePosition $options $geom]
+        set color [dict getdef $options color white]
+        set scale [drawShapeLengthOption $options scale 0.01 \
+            [dict get $geom width] [dict get $geom height] min]
+        set layer [dict getdef $options layer 0]
+        set anchor [dict getdef $options anchor center]
+        set font [dict getdef $options font "PTSans-Regular"]
+        set radians [drawShapeRadians $options]
 
-    Wish to draw text onto $p with \
-        position $position scale $scale text $text \
-        color $color radians $radians anchor $anchor font $font layer $layer
+        Wish to draw text onto $p with \
+            position $position scale $scale text $text \
+            color $color radians $radians anchor $anchor font $font layer $layer
+    } on error {err opts} {
+        Say $wisher has error $err with info $opts
+    }
 }
 
-When /someone/ wishes /p/ draws text /text/ {
+When /wisher/ wishes /p/ draws text /text/ {
     Wish $p draws text $text with color white
 }
 
-When /someone/ wishes /p/ draws a polyline /points/ with /...options/ &\
+When /wisher/ wishes /p/ draws a polyline /points/ with /...options/ &\
      /p/ has resolved geometry /geom/ {
-    if {![info exists options]} { return }
-    set points [drawShapePathPoints $points $geom $options]
-    set color [dict getdef $options color white]
-    set geomWidth [dict get $geom width]
-    set geomHeight [dict get $geom height]
-    set width [drawShapeLengthOption $options thickness 0.002 \
-        $geomWidth $geomHeight min]
-    set width [drawShapeLengthOption $options width $width \
-        $geomWidth $geomHeight min]
-    set layer [dict getdef $options layer 1]
-    set dashed [dict getdef $options dashed false]
+    try {
+        if {![info exists options]} { return }
+        set points [drawShapePathPoints $points $geom $options]
+        set color [dict getdef $options color white]
+        set geomWidth [dict get $geom width]
+        set geomHeight [dict get $geom height]
+        set width [drawShapeLengthOption $options thickness 0.002 \
+            $geomWidth $geomHeight min]
+        set width [drawShapeLengthOption $options width $width \
+            $geomWidth $geomHeight min]
+        set layer [dict getdef $options layer 1]
+        set dashed [dict getdef $options dashed false]
 
-    if {$dashed} {
-        set dashlength [drawShapeLengthOption $options dashlength 0.01 \
-            $geomWidth $geomHeight min]
-        set dashoffset [drawShapeLengthOption $options dashoffset 0 \
-            $geomWidth $geomHeight min]
-        Wish to draw a dashed line onto $p with \
-            points $points width $width color $color \
-            dashlength $dashlength dashoffset $dashoffset layer $layer
-    } else {
-        Wish to draw a line onto $p with \
-            points $points width $width color $color layer $layer
+        if {$dashed} {
+            set dashlength [drawShapeLengthOption $options dashlength 0.01 \
+                $geomWidth $geomHeight min]
+            set dashoffset [drawShapeLengthOption $options dashoffset 0 \
+                $geomWidth $geomHeight min]
+            Wish to draw a dashed line onto $p with \
+                points $points width $width color $color \
+                dashlength $dashlength dashoffset $dashoffset layer $layer
+        } else {
+            Wish to draw a line onto $p with \
+                points $points width $width color $color layer $layer
+        }
+    } on error {err opts} {
+        Say $wisher has error $err with info $opts
     }
 }
 
-When /someone/ wishes /p/ draws a polyline /points/ {
+When /wisher/ wishes /p/ draws a polyline /points/ {
     Wish $p draws a polyline $points with color white
 }
 
-When /someone/ wishes /p/ draws a polygon /points/ with /...options/ &\
+When /wisher/ wishes /p/ draws a polygon /points/ with /...options/ &\
      /p/ has resolved geometry /geom/ {
-    if {![info exists options]} { return }
-    set parsedPoints [drawShapePathPoints $points $geom $options]
-    set color [dict getdef $options color white]
-    set layer [dict getdef $options layer 1]
-    Wish to draw a polygon onto $p with points $parsedPoints color $color layer $layer
-}
-
-When /someone/ wishes /p/ draws a polygon /points/ {
-    Wish $p draws a polygon $points with color white
-}
-
-When /someone/ wishes /p/ draws points /points/ with /...options/ &\
-     /p/ has resolved geometry /geom/ {
-    if {![info exists options]} { return }
-    set points [drawShapePathPoints $points $geom $options]
-    set geomWidth [dict get $geom width]
-    set geomHeight [dict get $geom height]
-    set radius [drawShapeRadius $options 0.003 $geomWidth $geomHeight]
-    set thickness [drawShapeLengthOption $options thickness 0.001 \
-        $geomWidth $geomHeight min]
-    set color [dict getdef $options color white]
-    set filled [dict getdef $options filled true]
-    set layer [dict getdef $options layer 1]
-
-    foreach point $points {
-        Wish to draw a circle onto $p with \
-            center $point radius $radius thickness $thickness \
-            color $color filled $filled layer $layer
+    try {
+        if {![info exists options]} { return }
+        set parsedPoints [drawShapePathPoints $points $geom $options]
+        set color [dict getdef $options color white]
+        set layer [dict getdef $options layer 1]
+        Wish to draw a polygon onto $p with points $parsedPoints color $color layer $layer
+    } on error {err opts} {
+        Say $wisher has error $err with info $opts
     }
 }
 
-When /someone/ wishes /p/ draws points /points/ {
+When /wisher/ wishes /p/ draws a polygon /points/ {
+    Wish $p draws a polygon $points with color white
+}
+
+When /wisher/ wishes /p/ draws points /points/ with /...options/ &\
+     /p/ has resolved geometry /geom/ {
+    try {
+        if {![info exists options]} { return }
+        set points [drawShapePathPoints $points $geom $options]
+        set geomWidth [dict get $geom width]
+        set geomHeight [dict get $geom height]
+        set radius [drawShapeRadius $options 0.003 $geomWidth $geomHeight]
+        set thickness [drawShapeLengthOption $options thickness 0.001 \
+            $geomWidth $geomHeight min]
+        set color [dict getdef $options color white]
+        set filled [dict getdef $options filled true]
+        set layer [dict getdef $options layer 1]
+
+        foreach point $points {
+            Wish to draw a circle onto $p with \
+                center $point radius $radius thickness $thickness \
+                color $color filled $filled layer $layer
+        }
+    } on error {err opts} {
+        Say $wisher has error $err with info $opts
+    }
+}
+
+When /wisher/ wishes /p/ draws points /points/ {
     Wish $p draws points $points with color white
 }
 
-When /someone/ wishes /p/ draws a set of points /points/ with /...options/ {
+When /wisher/ wishes /p/ draws a set of points /points/ with /...options/ {
     if {![info exists options]} { return }
     Wish $p draws points $points with {*}$options
 }
 
-When /someone/ wishes /p/ draws a set of points /points/ {
+When /wisher/ wishes /p/ draws a set of points /points/ {
     Wish $p draws points $points
 }

--- a/builtin-programs/draw/shapes.folk
+++ b/builtin-programs/draw/shapes.folk
@@ -169,7 +169,6 @@ fn drawShapePathPoints {points geom options} {
 
 When /wisher/ wishes /p/ draws a /shape/ with /...options/ &\
      /p/ has resolved geometry /geom/ {
-    try {
         if {![info exists options]} { return }
         set shape [drawShapeCanonical $shape $options]
         set center [drawShapePosition $options $geom]
@@ -220,9 +219,6 @@ When /wisher/ wishes /p/ draws a /shape/ with /...options/ &\
             Wish to draw a line onto $p with \
                 points $points width $thickness color $color layer $layer
         }
-    } on error {err opts} {
-        Say $wisher has error $err with info $opts
-    }
 }
 
 When /wisher/ wishes /p/ draws a /shape/ {
@@ -231,7 +227,6 @@ When /wisher/ wishes /p/ draws a /shape/ {
 
 When /wisher/ wishes /p/ draws text /text/ with /...options/ &\
      /p/ has resolved geometry /geom/ {
-    try {
         if {![info exists options]} { return }
         set position [drawShapePosition $options $geom]
         set color [dict getdef $options color white]
@@ -245,9 +240,6 @@ When /wisher/ wishes /p/ draws text /text/ with /...options/ &\
         Wish to draw text onto $p with \
             position $position scale $scale text $text \
             color $color radians $radians anchor $anchor font $font layer $layer
-    } on error {err opts} {
-        Say $wisher has error $err with info $opts
-    }
 }
 
 When /wisher/ wishes /p/ draws text /text/ {
@@ -256,7 +248,6 @@ When /wisher/ wishes /p/ draws text /text/ {
 
 When /wisher/ wishes /p/ draws a polyline /points/ with /...options/ &\
      /p/ has resolved geometry /geom/ {
-    try {
         if {![info exists options]} { return }
         set points [drawShapePathPoints $points $geom $options]
         set color [dict getdef $options color white]
@@ -281,9 +272,6 @@ When /wisher/ wishes /p/ draws a polyline /points/ with /...options/ &\
             Wish to draw a line onto $p with \
                 points $points width $width color $color layer $layer
         }
-    } on error {err opts} {
-        Say $wisher has error $err with info $opts
-    }
 }
 
 When /wisher/ wishes /p/ draws a polyline /points/ {
@@ -292,15 +280,11 @@ When /wisher/ wishes /p/ draws a polyline /points/ {
 
 When /wisher/ wishes /p/ draws a polygon /points/ with /...options/ &\
      /p/ has resolved geometry /geom/ {
-    try {
         if {![info exists options]} { return }
         set parsedPoints [drawShapePathPoints $points $geom $options]
         set color [dict getdef $options color white]
         set layer [dict getdef $options layer 1]
         Wish to draw a polygon onto $p with points $parsedPoints color $color layer $layer
-    } on error {err opts} {
-        Say $wisher has error $err with info $opts
-    }
 }
 
 When /wisher/ wishes /p/ draws a polygon /points/ {
@@ -309,7 +293,6 @@ When /wisher/ wishes /p/ draws a polygon /points/ {
 
 When /wisher/ wishes /p/ draws points /points/ with /...options/ &\
      /p/ has resolved geometry /geom/ {
-    try {
         if {![info exists options]} { return }
         set points [drawShapePathPoints $points $geom $options]
         set geomWidth [dict get $geom width]
@@ -326,9 +309,6 @@ When /wisher/ wishes /p/ draws points /points/ with /...options/ &\
                 center $point radius $radius thickness $thickness \
                 color $color filled $filled layer $layer
         }
-    } on error {err opts} {
-        Say $wisher has error $err with info $opts
-    }
 }
 
 When /wisher/ wishes /p/ draws points /points/ {

--- a/builtin-programs/errors.folk
+++ b/builtin-programs/errors.folk
@@ -9,7 +9,27 @@ When /p/ has error /err/ with info /info/ {
     Wish $p is titled $err
 }
 
+When /someone/ claims /p/ has error /err/ with info /info/ {
+    When the clock time is /t/ {
+        if {[expr {(int($t * 5)) % 2}] == 1} {
+            Wish $p is outlined white
+        } else {
+            Wish $p is outlined red
+        }
+    }
+    Wish $p is titled $err
+}
+
 When /p/ has warning /w/ with info /info/ {
+    When the clock time is /t/ {
+        if {[expr {(int($t * 5)) % 2}] != 1} {
+            Wish $p is outlined yellow
+        }
+    }
+    Wish $p is titled $w
+}
+
+When /someone/ claims /p/ has warning /w/ with info /info/ {
     When the clock time is /t/ {
         if {[expr {(int($t * 5)) % 2}] != 1} {
             Wish $p is outlined yellow

--- a/db.c
+++ b/db.c
@@ -208,6 +208,9 @@ typedef struct Statement {
     // The program that caused the chain of matches leading to this statement.
     char causalityFileName[100];
 
+    // The match that created this statement, if any.
+    MatchRef parentMatch;
+
     // Mutable statement properties:
     // -----
 
@@ -232,6 +235,9 @@ typedef struct Match {
     // Immutable match properties:
     // -----
     int workerThreadIndex;
+
+    int nParentStatements;
+    StatementRef* parentStatements;
 
     // Mutable match properties:
     // -----
@@ -473,7 +479,8 @@ static StatementRef statementNew(Db* db, Clause* clause,
                                  long keepMs, AtomicallyVersion* atomicallyVersion,
                                  const char* sourceFileName,
                                  int sourceLineNumber,
-                                 const char* causalityFileName) {
+                                 const char* causalityFileName,
+                                 MatchRef parentMatch) {
     StatementRef ret;
     Statement* stmt = NULL;
 
@@ -511,6 +518,7 @@ static StatementRef statementNew(Db* db, Clause* clause,
         stmt->atomicallyVersion = NULL;
     }
     stmt->parentCount = 1;
+    stmt->parentMatch = parentMatch;
 
     destructorSetInit(&stmt->destructorSet);
     pthread_mutex_init(&stmt->destructorSetMutex, NULL);
@@ -744,6 +752,7 @@ Match* matchAcquire(Db* db, MatchRef ref) {
         return NULL;
     }
 }
+
 static void matchDestroy(Match* match);
 void matchRelease(Db* db, Match* match) {
     if (genRcRelease(&match->genRc)) {
@@ -767,9 +776,15 @@ MatchRef matchRef(Db* db, Match* match) {
 
 static MatchRef matchNew(Db* db,
                          AtomicallyVersion* atomicallyVersion,
-                         int workerThreadIndex) {
+                         int workerThreadIndex,
+                         int nParents, StatementRef* parents) {
     MatchRef ret;
     Match* match = NULL;
+
+    StatementRef* parentStatementsRefCopy = malloc(nParents * sizeof(StatementRef));
+    for (int i = 0; i < nParents; i++) {
+        parentStatementsRefCopy[i] = parents[i];
+    }
 
     // Look for a free match slot to use:
     while (1) {
@@ -792,8 +807,13 @@ static MatchRef matchNew(Db* db,
 
     // We should have exclusive access to match right now.
 
-    atomic_store_explicit(&match->childStatements, listOfEdgeToNew(8), memory_order_relaxed);
     match->parentWasRemoved = false;
+    match->isCompleted = false;
+
+    match->nParentStatements = nParents;
+    match->parentStatements = parentStatementsRefCopy;
+
+    atomic_store_explicit(&match->childStatements, listOfEdgeToNew(8), memory_order_relaxed);
 
     pthread_mutexattr_t mta;
     pthread_mutexattr_init(&mta);
@@ -816,6 +836,11 @@ static MatchRef matchNew(Db* db,
 static void matchDestroy(Match* match) {
     assert(atomic_load_explicit(&match->childStatements, memory_order_relaxed)
            == CHILD_STATEMENTS_REMOVING);
+
+    if (match->parentStatements != NULL) {
+        free(match->parentStatements);
+        match->parentStatements = NULL;
+    }
 
     // Fire any destructors.
     pthread_mutex_lock(&match->destructorSetMutex);
@@ -1255,10 +1280,10 @@ Statement* dbInsertOrReuseStatement(Db* db, Clause* clause,
     // We'll provisionally create a new statement to add.
     // 
     // Also transfers ownership of `clause` to the DB.
-    StatementRef ref = statementNew(db, clause,
-                                    keepMs, atomicallyVersion,
-                                    sourceFileName, sourceLineNumber,
-                                    parentMatch ? parentMatch->causalityFileName : sourceFileName);
+    StatementRef ref = statementNew(db, clause, keepMs, atomicallyVersion,
+                                   sourceFileName, sourceLineNumber,
+                                   parentMatch ? parentMatch->causalityFileName : sourceFileName,
+                                   parentMatchRef);
 
     // Now try to add to the trie: the trieAdd operation will
     // atomically detect if the clause is already present.
@@ -1376,7 +1401,7 @@ Statement* dbInsertOrReuseStatement(Db* db, Clause* clause,
 Match* dbInsertMatch(Db* db, int nParents, StatementRef parents[],
                      AtomicallyVersion* atomicallyVersion,
                      int workerThreadIndex) {
-    MatchRef ref = matchNew(db, atomicallyVersion, workerThreadIndex);
+    MatchRef ref = matchNew(db, atomicallyVersion, workerThreadIndex, nParents, parents);
     Match* match = matchAcquire(db, ref);
     assert(match != NULL);
 
@@ -1568,4 +1593,48 @@ Statement* dbHoldStatement(Db* db,
         clauseFree(clause);
         return NULL;
     }
+}
+
+// Returns a comma-separated list of unique files in the causal trace.
+char* dbGetCausalTrace(Db* db, MatchRef startMatchRef) {
+    char* trace = malloc(4096);
+    trace[0] = '\0';
+    
+    // Simple BFS queue
+    MatchRef queue[1024];
+    int head = 0, tail = 0;
+    
+    queue[tail++] = startMatchRef;
+    
+    while (head < tail && head < 1024) {
+        MatchRef mref = queue[head++];
+        Match* m = matchAcquire(db, mref);
+        if (!m) continue;
+        
+        for (int i = 0; i < m->nParentStatements; i++) {
+            Statement* stmt = statementAcquire(db, m->parentStatements[i]);
+            if (!stmt) continue;
+            
+            const char* fname = stmt->sourceFileName;
+            // add to trace if unique
+            if (fname && strlen(fname) > 0 && strcmp(fname, "(null)") != 0) {
+                // Check if already in trace
+                if (!strstr(trace, fname)) {
+                    if (strlen(trace) > 0) strcat(trace, ",");
+                    strcat(trace, fname);
+                }
+            }
+            
+            if (!matchRefIsNull(stmt->parentMatch)) {
+                if (tail < 1024) {
+                    queue[tail++] = stmt->parentMatch;
+                }
+            }
+            
+            statementRelease(db, stmt);
+        }
+        matchRelease(db, m);
+    }
+    
+    return trace;
 }

--- a/db.c
+++ b/db.c
@@ -205,6 +205,9 @@ typedef struct Statement {
     char sourceFileName[100];
     int sourceLineNumber;
 
+    // The program that caused the chain of matches leading to this statement.
+    char causalityFileName[100];
+
     // Mutable statement properties:
     // -----
 
@@ -245,6 +248,8 @@ typedef struct Match {
     // workerThread is subject to termination signal (SIGUSR1) if the
     // match is removed.
     _Atomic bool isCompleted;
+
+    char causalityFileName[100];
 
     DestructorSet destructorSet;
     pthread_mutex_t destructorSetMutex;
@@ -467,7 +472,8 @@ StatementRef statementRef(Db* db, Statement* stmt) {
 static StatementRef statementNew(Db* db, Clause* clause,
                                  long keepMs, AtomicallyVersion* atomicallyVersion,
                                  const char* sourceFileName,
-                                 int sourceLineNumber) {
+                                 int sourceLineNumber,
+                                 const char* causalityFileName) {
     StatementRef ret;
     Statement* stmt = NULL;
 
@@ -521,6 +527,14 @@ static StatementRef statementNew(Db* db, Clause* clause,
              "%s", sourceFileName);
     stmt->sourceLineNumber = sourceLineNumber;
 
+    if (causalityFileName != NULL) {
+        snprintf(stmt->causalityFileName, sizeof(stmt->causalityFileName),
+                 "%s", causalityFileName);
+    } else {
+        snprintf(stmt->causalityFileName, sizeof(stmt->causalityFileName),
+                 "%s", sourceFileName);
+    }
+
     return ret;
 }
 
@@ -556,6 +570,10 @@ char* statementSourceFileName(Statement* stmt) {
 }
 int statementSourceLineNumber(Statement* stmt) {
     return stmt->sourceLineNumber;
+}
+
+char* statementCausalityFileName(Statement* stmt) {
+    return stmt->causalityFileName;
 }
 
 int statementIncompleteChildMatchesCount(Db* db, Statement* stmt) {
@@ -786,6 +804,8 @@ static MatchRef matchNew(Db* db,
     match->atomicallyVersion = atomicallyVersion;
     match->workerThreadIndex = workerThreadIndex;
     match->isCompleted = false;
+
+    memset(match->causalityFileName, 0, sizeof(match->causalityFileName));
 
     destructorSetInit(&match->destructorSet);
     pthread_mutex_init(&match->destructorSetMutex, NULL);
@@ -1237,7 +1257,8 @@ Statement* dbInsertOrReuseStatement(Db* db, Clause* clause,
     // Also transfers ownership of `clause` to the DB.
     StatementRef ref = statementNew(db, clause,
                                     keepMs, atomicallyVersion,
-                                    sourceFileName, sourceLineNumber);
+                                    sourceFileName, sourceLineNumber,
+                                    parentMatch ? parentMatch->causalityFileName : sourceFileName);
 
     // Now try to add to the trie: the trieAdd operation will
     // atomically detect if the clause is already present.
@@ -1392,6 +1413,12 @@ Match* dbInsertMatch(Db* db, int nParents, StatementRef parents[],
                              &parentStatements[i]->destructorSet);
         pthread_mutex_unlock(&match->destructorSetMutex);
         pthread_mutex_unlock(&parentStatements[i]->destructorSetMutex);
+        
+        // Inherit causality from the last parent (usually the triggering statement).
+        if (i == nParents - 1) {
+            snprintf(match->causalityFileName, sizeof(match->causalityFileName),
+                     "%s", parentStatements[i]->causalityFileName);
+        }
     }
 
 done:

--- a/db.h
+++ b/db.h
@@ -144,6 +144,10 @@ Statement* dbInsertOrReuseStatement(Db* db, Clause* clause,
                                     MatchRef parent,
                                     StatementRef* outReusedStatementRef);
 
+// Returns a comma-separated list of unique files in the causal trace.
+// The caller is responsible for freeing the returned string.
+char* dbGetCausalTrace(Db* db, MatchRef startMatchRef);
+
 // Call when you're about to begin a match (i.e., evaluating the body
 // of a When) -- creates the Match object that you'll attach any
 // emitted Statements to. The worker thread is stored with the Match

--- a/db.h
+++ b/db.h
@@ -56,6 +56,7 @@ Clause* statementClause(Statement* stmt);
 AtomicallyVersion* statementAtomicallyVersion(Statement* stmt);
 char* statementSourceFileName(Statement* stmt);
 int statementSourceLineNumber(Statement* stmt);
+char* statementCausalityFileName(Statement* stmt);
 
 int statementIncompleteChildMatchesCount(Db* db, Statement* stmt);
 

--- a/folk.c
+++ b/folk.c
@@ -933,26 +933,63 @@ static void runWhenBlock(StatementRef whenRef, Clause* whenPattern, StatementRef
     statementRelease(db, when);
     if (stmt != NULL) { statementRelease(db, stmt); }
 
-    matchCompleted(self->currentMatch);
-    matchRelease(db, self->currentMatch);
-    self->currentMatch = NULL;
-
     if (error == JIM_ERR) {
         Jim_MakeErrorMessage(interp);
-        const char *errorMessage = Jim_GetString(Jim_GetResult(interp), NULL);
+        const char *errorMessageRaw = Jim_GetString(Jim_GetResult(interp), NULL);
+        char *errorMessage = strdup(errorMessageRaw ? errorMessageRaw : "Unknown error");
+        if (strlen(errorMessage) == 0) {
+            free(errorMessage);
+            errorMessage = strdup("Unknown error");
+        }
         int bodyLen = termLen(body);
         if (bodyLen > 100) bodyLen = 100;
         fprintf(stderr, "Uncaught error running When (%.*s):\n  %s\n",
                 bodyLen, termPtr(body), errorMessage);
-        /* Jim_FreeInterp(interp); */
-        /* exit(EXIT_FAILURE); */
 
+        char* trace = dbGetCausalTrace(db, matchRef(db, self->currentMatch));
+        char* tok = strtok(trace, ",");
+        while (tok) {
+            while (*tok == ' ') tok++;
+            if (strlen(tok) > 0) {
+                Jim_Obj *errorInfoStr = interp->stackTrace;
+                if (errorInfoStr == NULL) {
+                    errorInfoStr = Jim_NewStringObj(interp, "", 0);
+                }
+                Jim_Obj *errorInfoObj = Jim_NewDictObj(interp, NULL, 0);
+                Jim_DictAddElement(interp, errorInfoObj,
+                                   Jim_NewStringObj(interp, "-errorinfo", -1),
+                                   errorInfoStr);
+                Jim_Obj *cmd[] = {
+                    Jim_NewStringObj(interp, "SayWithSource", -1),
+                    Jim_NewStringObj(interp, tok, -1), /* sourceFileName */
+                    Jim_NewIntObj(interp, 1),          /* sourceLineNumber */
+                    Jim_NewIntObj(interp, 0),          /* keepMs */
+                    Jim_NewStringObj(interp, "", 0),   /* atomicallyVersion */
+                    Jim_NewStringObj(interp, "", 0),   /* destructorCode */
+                    Jim_NewStringObj(interp, tok, -1),
+                    Jim_NewStringObj(interp, "has", -1),
+                    Jim_NewStringObj(interp, "error", -1),
+                    Jim_NewStringObj(interp, errorMessage, -1),
+                    Jim_NewStringObj(interp, "with", -1),
+                    Jim_NewStringObj(interp, "info", -1),
+                    errorInfoObj
+                };
+                Jim_EvalObjVector(interp, 13, cmd);
+            }
+            tok = strtok(NULL, ",");
+        }
+        free(errorMessage);
+        free(trace);
     } else if (error == JIM_SIGNAL) {
         // FIXME: I think this is the only signal handler path that
         // actually runs mostly.
         interp->sigmask = 0;
         workerExit();
     }
+
+    matchCompleted(self->currentMatch);
+    matchRelease(db, self->currentMatch);
+    self->currentMatch = NULL;
 }
 
 // Caller is responsible for freeing passed in clauses

--- a/folk.c
+++ b/folk.c
@@ -539,7 +539,7 @@ static int __statementOfCurrentMatchSourceInfoFunc(Jim_Interp *interp, int argc,
         return JIM_OK;
     }
 
-    const char* fileName = statementSourceFileName(stmt);
+    const char* fileName = statementCausalityFileName(stmt);
     int lineNumber = statementSourceLineNumber(stmt);
     Jim_Obj* result[2] = {
         Jim_NewStringObj(interp, fileName ? fileName : "", -1),

--- a/prelude.tcl
+++ b/prelude.tcl
@@ -192,16 +192,9 @@ proc evaluateBlock {whenBody envStack} {
             # (TODO: might be a better way?)
             Hold! -key $this-error -on $this $this has error $err with info $opts
         } else {
-            Say $this has error $err with info $opts
-
-            # Automatically blame the statement that triggered us, if any
-            set triggerInfo [__statementOfCurrentMatchSourceInfo]
-            if {[llength $triggerInfo] > 0} {
-                set triggerProgram [lindex $triggerInfo 0]
-                if {$triggerProgram ne $this && $triggerProgram ne ""} {
-                    Say $triggerProgram has error $err with info $opts
-                }
-            }
+            # Throw the error up to C so runWhenBlock can walk the causal graph
+            # and bubble the error to all trigger programs automatically.
+            return -code error -errorinfo $errorInfo $err
         }
     }
 }

--- a/prelude.tcl
+++ b/prelude.tcl
@@ -193,6 +193,15 @@ proc evaluateBlock {whenBody envStack} {
             Hold! -key $this-error -on $this $this has error $err with info $opts
         } else {
             Say $this has error $err with info $opts
+
+            # Automatically blame the statement that triggered us, if any
+            set triggerInfo [__statementOfCurrentMatchSourceInfo]
+            if {[llength $triggerInfo] > 0} {
+                set triggerProgram [lindex $triggerInfo 0]
+                if {$triggerProgram ne $this && $triggerProgram ne ""} {
+                    Say $triggerProgram has error $err with info $opts
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
After merging #261 we introduced an issue with `draw/shapes.folk` errors, for example:

```tcl
Wish $this draws a circle with radius 10 filled true
#                                      ^ missing units, e.g. 10mm, 10cm, 10m
```

this should produce an error, but it gets swallowed by the `shapes.folk` file.

| Before | After |
|--------|--------|
| No error | Now we correctly error |
| <img width="1112" height="805" alt="Screenshot 2026-06-18 at 19 09 19" src="https://github.com/user-attachments/assets/bc1b5f3d-fd48-47b1-9d0b-22c8a043e135" /> | <img width="1110" height="734" alt="Screenshot 2026-06-18 at 19 07 38" src="https://github.com/user-attachments/assets/29a04134-78b1-46e8-997f-bb78c044ca1f" /> | 

----

## The fix
1. We change `someone` to `wisher` so we don't lose the context of the wisher program
2. We wrap anything in `draw/shapes.folk` that could throw an error in `try/on error` and bubble the error to the wisher.
