### PR TITLE
calibrate.folk: Center projected calibration tags in view.

### DIFF
--- a/builtin-programs/calibrate/calibrate.folk
+++ b/builtin-programs/calibrate/calibrate.folk
@@ -64,7 +64,7 @@ When camera /camera/ has width /cameraWidth/ height /cameraHeight/ &\
 
     set tagSideLength 1.0
     set tagOuterLength [expr {$tagSideLength * 10/6}]
-    set pad $tagSideLength
+    set pad [expr {$tagSideLength / 3}]
 
     # Unit model's 2D coordinates have inner tag side length of 1.0:
     # scale it to real-world coordinates.
@@ -111,16 +111,26 @@ When camera /camera/ has width /cameraWidth/ height /cameraHeight/ &\
     fn HoldDefaultModel! {scale} {
         # Default model: just makes the tags fill most of the middle
         # of the projector area.
-        set tagSideLengthPixels [::math::min $($displayWidth/($COLS * ($tagOuterLength + $pad))) \
-                                     $($displayHeight/($ROWS * ($tagOuterLength + $pad)))]
+
+        # This has been adjusted with a scaling factor
+        # to account for the inclusion of labels on each side.
+        set tagSideLengthPixels [::math::min $(($displayWidth * 0.75)/($COLS * ($tagOuterLength + $pad))) \
+                                     $(($displayHeight * 0.75)/($ROWS * ($tagOuterLength + $pad)))]
         set tagSideLengthPixels [expr {$tagSideLengthPixels * $scale}]
 
-        # TODO: Center this on the projector area.
+        # Calculate offsets to center calibration tags in the projection area.
+        set projWidthPixels [expr {$COLS * ($tagSideLengthPixels * 10/6 + $pad)}]
+        set projWidthPixels [expr {$projWidthPixels * 1.1}]
+        set projHeightPixels [expr {$ROWS * ($tagSideLengthPixels * 10/6 + $pad)}]
+        set projHeightPixels [expr {$projHeightPixels * 1.1}]
+        set xOffset [expr {round(($displayWidth - $projWidthPixels) / 2)}]
+        set yOffset [expr {round(($displayHeight - $projHeightPixels) / 2)}]
+
         set H_modelToDisplay [$matLib estimateHomography [subst {
-            {$printedSideLengthM $printedSideLengthM $tagSideLengthPixels $tagSideLengthPixels}
-            {$printedSideLengthM 0 $tagSideLengthPixels 0}
-            {0 $printedSideLengthM 0 $tagSideLengthPixels}
-            {0 0 0 0}
+            {$printedSideLengthM $printedSideLengthM [expr {$tagSideLengthPixels + $xOffset}] [expr {$tagSideLengthPixels + $yOffset}]}
+            {$printedSideLengthM 0 [expr {$tagSideLengthPixels + $xOffset}] $yOffset}
+            {0 $printedSideLengthM $xOffset [expr {$tagSideLengthPixels + $yOffset}]}
+            {0 0 $xOffset $yOffset}
         }]]
         Hold! -key H_modelToDisplay {
             # Default model and version: nothing rotated.


### PR DESCRIPTION
These changes center the projected calibration tags rather than anchoring them in the top-left corner, which can cause issues with initial tag fitting depending on how wide the projection area is relative to the camera.

**In addition to the basic math:**

I changed the calculation of the pad value to match the calculation of pad in `model.folk`, e.g. `set pad [expr {$tagSideLength / 3}]`, whereas previously it was simply set as `$tagSideLength`. I discussed this with Omar and Andrés and I believe this may have been an unintentional mismatch, but can revert if needed.

I've added scaling factors (`0.75x` to downsize tags and `1.1x` to adjust the bounding box when calculating the homgraphy offsets) to ensure tags will show up uncropped after making the correction above. The original math used to tile them is (I believe) written to occupy a full screen height with only the tags, ignoring the labels applied to all four sides.

Because the label sizing is a derived value from the geometry of what is being labelled, I don't think there's a direct way to account for their sizing exactly in calculating the centering margins. But the scaling factors I've used should mean that it will always be in view even at the largest size.